### PR TITLE
fix typo from 'fdsp' to 'fsdp'

### DIFF
--- a/utils/Utils.py
+++ b/utils/Utils.py
@@ -136,7 +136,7 @@ class Utils:
             case _ if SyncStatus == 'fsd':
                 with Image.open("./images/SyncStatus/3.png") as _syncStatus:
                     return _syncStatus.copy()
-            case _ if SyncStatus == 'fdsp':
+            case _ if SyncStatus == 'fsdp':
                 with Image.open("./images/SyncStatus/4.png") as _syncStatus:
                     return _syncStatus.copy()
             case _ if SyncStatus == 'sync':


### PR DESCRIPTION
First, it's really a nice program!
I came into a trouble when generating b50 from diving-fish, and found that this problem was due to a typo that spelled 'fsdp' (Full Sync DX+) wrong, which lead to SyncStatus==None, and raised exception when generating b50
Fixed this typo :)