### PR TITLE
Some improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ tqdm>=4.0.0
 Pillow==10.4.0
 pytubefix>=8.5.0
 pyyaml>=6.0.1
-bilibili-api-python>=16.3.0
+bilibili-api-python~=16.3.0
 flask>=3.1.0
 streamlit>=1.40.0
 lxml>=5.3.0
 streamlit_sortables>=0.3.1
 streamlit_searchbox>=0.1.22
+httpx

--- a/st_pages/Confirm_Videos.py
+++ b/st_pages/Confirm_Videos.py
@@ -85,7 +85,7 @@ def st_download_video(placeholder, dl_instance, G_config, b50_config):
                 write_container.write(f"【{i}/50】{result['info']}")
 
                 # 等待几秒，以减少被检测为bot的风险
-                if search_wait_time[0] > 0 and search_wait_time[1] > search_wait_time[0]:
+                if search_wait_time[0] > 0 and search_wait_time[1] > search_wait_time[0] and result['status'] == 'success':
                     time.sleep(random.randint(search_wait_time[0], search_wait_time[1]))
 
             st.success("下载完成！请点击下一步按钮核对视频素材的详细信息。")

--- a/utils/ImageUtils.py
+++ b/utils/ImageUtils.py
@@ -279,7 +279,7 @@ class MaiImageGenerater:
 
                 # 游玩次数（暂无获取方式，b50data中若有手动填写即可显示）
                 if "playCount" in record_detail:
-                    PlayCount = record_detail["playCount"]
+                    PlayCount = int(record_detail["playCount"])
                 else:
                     PlayCount = 0
                 if PlayCount >= 1:


### PR DESCRIPTION
主要改进与修复的点包括

1. 下载谱面视频时，如果检测到本地已有缓存，不再触发循环末尾的等待 (#60 )
2. 直接 `pip install -r requirements.txt` 似乎并不会安装 `utils/video_crawler.py` 中依赖的 `httpx` 包。
3. 根据 `bilibili_api` 库的[官方文档](https://nemo2011.github.io/bilibili-api/#/examples/login_v2)，`utils/video_crawler.py` 中引入的 `login` 模块已在 `17.0.0` 版本中移除。故对版本号做出额外限制。
4. 修复生成图片中游玩次数被显示为小数的问题。