### PR TITLE
fix: resolve SyntaxError in Make_Custom_Save.py

### DIFF
--- a/st_pages/Make_Custom_Save.py
+++ b/st_pages/Make_Custom_Save.py
@@ -750,10 +750,10 @@ def update_record_grid(grid, external_placeholder):
                     st.session_state.cur_search_level_index = level_index
                     if level_index >= 4:
                         extra_tips = f"（注：如果乐曲不存在{level_label}难度，将不会显示在搜索栏中，请切换到其他难度）"
-                level_label_tips.markdown(f"> 当前搜索的谱面难度: **{
-                    level_label_lists.get(
-                        cur_game_type, ['BASIC', 'ADVANCED', 'EXPERT', 'MASTER', 'RE:MASTER'])[st.session_state.cur_search_level_index]
-                    }** {extra_tips}"
+                current_level_label =  level_label_lists.get(
+                        cur_game_type, ['BASIC', 'ADVANCED', 'EXPERT', 'MASTER', 'RE:MASTER']) [st.session_state.cur_search_level_index]
+                level_label_tips.markdown(
+                    f"> 当前搜索的谱面难度: **{ current_level_label }** {extra_tips}"
                 )
 
             col1, col2 = st.columns([3, 1])


### PR DESCRIPTION
Fix a SyntaxError caused by a multiline f-string in Make_Custom_Save.py.

The original code places an expression across multiple lines inside an f-string, which is invalid in Python and causes a SyntaxError.

This PR refactors the code slightly to ensure correct syntax and keep the original behavior unchanged.

---

修复 Make_Custom_Save.py 中由于 f-string 跨行导致的 SyntaxError。

原代码在 f-string 的 {} 表达式中换行，导致 Python 报错。

本次修改保证语法正确，同时不影响原有功能。