### PR TITLE
feat: Taichi GPU 加速渲染管线

### DIFF
--- a/global_config.yaml
+++ b/global_config.yaml
@@ -18,6 +18,7 @@ SEARCH_WAIT_TIME: !!python/tuple
 - 1
 - 3
 USE_ALL_CACHE: false
+USE_GPU_ACCEL: false
 USE_AUTO_PO_TOKEN: false
 USE_CUSTOM_PO_TOKEN: false
 USE_OAUTH: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ jieba>=0.42.1
 pilmoji>=2.0.5
 pyperclip>=1.11.0
 Pillow
+taichi>=1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,3 @@ jieba>=0.42.1
 pilmoji>=2.0.5
 pyperclip>=1.11.0
 Pillow
-taichi>=1.7.0

--- a/st_pages/Composite_Videos.py
+++ b/st_pages/Composite_Videos.py
@@ -152,10 +152,24 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
     video_res = (v_res_width, v_res_height)
 
     placeholder = st.empty()
+
+    # GPU 加速时创建 Streamlit 进度回调
+    def _make_st_progress(container):
+        progress_bar = container.progress(0, text="准备渲染...")
+        status_text = container.empty()
+        def callback(clip_idx, total_clips, frame, total_frames, clip_name):
+            clip_progress = clip_idx / total_clips if total_clips > 0 else 0
+            frame_progress = frame / total_frames if total_frames > 0 else 0
+            overall = (clip_idx + frame_progress) / total_clips if total_clips > 0 else 0
+            progress_bar.progress(min(overall, 1.0),
+                text=f"🚀 片段 {clip_idx+1}/{total_clips}: {clip_name} ({frame}/{total_frames}帧)")
+        return callback if gpu_accel else None
+
     if v_mode_index == 0:
         try:
             with placeholder.container(border=True, height=560):
                 st.warning("生成过程中请不要手动跳转到其他页面，或刷新本页面，否则可能导致生成失败！")
+                progress_cb = _make_st_progress(st.container()) if gpu_accel else None
                 with st.spinner("正在生成所有视频片段……"):
                     render_all_video_clips(
                         game_type=G_type,
@@ -168,9 +182,11 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
                         ending_configs=ending_configs,
                         trans_time=trans_time,
                         force_render=force_render_clip,
-                        use_gpu_accel=gpu_accel
+                        use_gpu_accel=gpu_accel,
+                        progress_callback=progress_cb
                     )
-                    st.info("已启动批量视频片段生成，请在控制台窗口查看进度……")
+                    if not gpu_accel:
+                        st.info("已启动批量视频片段生成，请在控制台窗口查看进度……")
             st.success("视频片段生成结束！点击下方按钮打开视频所在文件夹")
         except Exception as e:
             st.error(f"视频片段生成失败，错误详情: {traceback.print_exc()}")
@@ -180,6 +196,7 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
             with placeholder.container(border=True, height=560):
                 st.info("请注意，生成完整视频通常需要一定时间，您可以在控制台窗口中查看进度")
                 st.warning("生成过程中请不要手动跳转到其他页面，或刷新本页面，否则可能导致生成失败！")
+                progress_cb = _make_st_progress(st.container()) if gpu_accel else None
                 with st.spinner("正在生成完整视频……"):
                     output_info = render_complete_full_video(
                         username=username,
@@ -194,7 +211,8 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
                         video_trans_enable=trans_enable,
                         video_trans_time=trans_time,
                         full_last_clip=False,
-                        use_gpu_accel=gpu_accel
+                        use_gpu_accel=gpu_accel,
+                        progress_callback=progress_cb
                     )
                     st.write(f"【{output_info['info']}")
             st.success("完整视频生成结束！点击下方按钮打开视频所在文件夹")

--- a/st_pages/Composite_Videos.py
+++ b/st_pages/Composite_Videos.py
@@ -99,6 +99,17 @@ with st.container(border=True):
     st.write("视频比特率(kbps)")  
     v_bitrate = st.number_input("视频比特率", min_value=1000, max_value=10000, value=_video_bitrate)
 
+_gpu_accel = G_config.get('USE_GPU_ACCEL', False)
+with st.container(border=True):
+    st.write("🚀 GPU 加速渲染（实验性）")
+    gpu_accel = st.checkbox(
+        "启用 Taichi GPU 加速",
+        value=_gpu_accel,
+        help="使用 Taichi GPU 合成 + FFmpeg 硬件编码加速视频渲染。需要安装 taichi 库（pip install taichi）。"
+             "启用后将自动检测最佳 GPU 后端（CUDA/Vulkan/Metal）和硬件编码器（NVENC/VideoToolbox 等）。"
+             "如果 GPU 不可用，将自动回退到 CPU 渲染。"
+    )
+
 v_mode_index = options.index(mode_str)
 v_bitrate_kbps = f"{v_bitrate}k"
 
@@ -132,6 +143,7 @@ def save_video_render_config():
     G_config['VIDEO_BITRATE'] = v_bitrate
     G_config['VIDEO_TRANS_ENABLE'] = trans_enable
     G_config['VIDEO_TRANS_TIME'] = trans_time
+    G_config['USE_GPU_ACCEL'] = gpu_accel
     write_global_config(G_config)
     st.toast("配置已保存！")
 
@@ -155,7 +167,8 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
                         intro_configs=intro_configs,
                         ending_configs=ending_configs,
                         trans_time=trans_time,
-                        force_render=force_render_clip
+                        force_render=force_render_clip,
+                        use_gpu_accel=gpu_accel
                     )
                     st.info("已启动批量视频片段生成，请在控制台窗口查看进度……")
             st.success("视频片段生成结束！点击下方按钮打开视频所在文件夹")
@@ -180,7 +193,8 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
                         video_bitrate=v_bitrate_kbps,
                         video_trans_enable=trans_enable,
                         video_trans_time=trans_time,
-                        full_last_clip=False
+                        full_last_clip=False,
+                        use_gpu_accel=gpu_accel
                     )
                     st.write(f"【{output_info['info']}")
             st.success("完整视频生成结束！点击下方按钮打开视频所在文件夹")

--- a/utils/AccelRenderer.py
+++ b/utils/AccelRenderer.py
@@ -1,0 +1,641 @@
+"""
+AccelRenderer.py - 加速渲染管线
+
+使用 Taichi GPU 合成 + FFmpeg 硬件编码，替代 MoviePy 的逐帧 CPU 渲染。
+提供与 VideoUtils.py 兼容的 API，可作为可选后端使用。
+"""
+
+import os
+import subprocess
+import traceback
+import numpy as np
+import cv2
+from PIL import Image
+from typing import Optional, Tuple, List
+
+from utils.PageUtils import remove_invalid_chars
+
+
+# ============================================================================
+# FFmpeg 硬件编码器检测
+# ============================================================================
+
+_hw_encoder_cache = None
+
+def detect_hw_encoder() -> Tuple[str, str]:
+    """
+    检测可用的 FFmpeg 硬件编码器。
+    
+    Returns:
+        (codec_name, display_name) 元组
+    """
+    global _hw_encoder_cache
+    if _hw_encoder_cache is not None:
+        return _hw_encoder_cache
+
+    encoders = [
+        ('h264_videotoolbox', 'macOS VideoToolbox'),
+        ('h264_nvenc', 'NVIDIA NVENC'),
+        ('h264_amf', 'AMD AMF'),
+        ('h264_qsv', 'Intel QuickSync'),
+    ]
+
+    try:
+        result = subprocess.run(
+            ['ffmpeg', '-hide_banner', '-encoders'],
+            capture_output=True, text=True, timeout=10
+        )
+        output = result.stdout + result.stderr
+        for codec, name in encoders:
+            if codec in output:
+                _hw_encoder_cache = (codec, name)
+                print(f"[AccelRenderer] ✓ 检测到硬件编码器: {name} ({codec})")
+                return _hw_encoder_cache
+    except Exception as e:
+        print(f"[AccelRenderer] Warning: 检测硬件编码器失败: {e}")
+
+    _hw_encoder_cache = ('libx264', 'CPU Software (libx264)')
+    print(f"[AccelRenderer] 未检测到硬件编码器，使用 CPU 软件编码")
+    return _hw_encoder_cache
+
+
+def get_ffmpeg_encoder_args(codec: str, bitrate: str = "5000k") -> list:
+    """根据编码器返回对应的 FFmpeg 参数"""
+    if codec == 'h264_videotoolbox':
+        return ['-c:v', codec, '-b:v', bitrate, '-allow_sw', '1']
+    elif codec == 'h264_nvenc':
+        return ['-c:v', codec, '-b:v', bitrate, '-preset', 'p4', '-tune', 'hq']
+    elif codec == 'h264_amf':
+        return ['-c:v', codec, '-b:v', bitrate, '-quality', 'balanced']
+    elif codec == 'h264_qsv':
+        return ['-c:v', codec, '-b:v', bitrate, '-preset', 'medium']
+    else:
+        return ['-c:v', 'libx264', '-b:v', bitrate, '-preset', 'medium']
+
+
+# ============================================================================
+# 视频帧读取工具
+# ============================================================================
+
+class VideoFrameReader:
+    """使用 OpenCV 读取视频帧"""
+
+    def __init__(self, video_path: str):
+        self.path = video_path
+        self.cap = cv2.VideoCapture(video_path)
+        if not self.cap.isOpened():
+            raise IOError(f"无法打开视频: {video_path}")
+        self.fps = self.cap.get(cv2.CAP_PROP_FPS) or 30.0
+        self.frame_count = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        self.width = int(self.cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        self.height = int(self.cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        self.duration = self.frame_count / self.fps if self.fps > 0 else 0
+
+    def get_frame(self, time_sec: float) -> Optional[np.ndarray]:
+        """获取指定时间点的帧 (RGB uint8)"""
+        frame_idx = int(time_sec * self.fps)
+        frame_idx = max(0, min(frame_idx, self.frame_count - 1))
+        self.cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+        ret, frame = self.cap.read()
+        if ret:
+            return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        return None
+
+    def close(self):
+        if self.cap:
+            self.cap.release()
+
+    def __del__(self):
+        self.close()
+
+
+# ============================================================================
+# FFmpeg 写入管线
+# ============================================================================
+
+class FFmpegWriter:
+    """通过 stdin pipe 向 FFmpeg 写入原始帧数据"""
+
+    def __init__(self, output_path: str, width: int, height: int,
+                 fps: int = 30, codec: str = None, bitrate: str = "5000k",
+                 audio_path: str = None, audio_start: float = 0, audio_duration: float = None):
+        self.output_path = output_path
+        self.width = width
+        self.height = height
+
+        if codec is None:
+            codec, _ = detect_hw_encoder()
+
+        encoder_args = get_ffmpeg_encoder_args(codec, bitrate)
+
+        cmd = [
+            'ffmpeg', '-y', '-hide_banner', '-loglevel', 'warning',
+            # 视频输入 (raw frames from stdin)
+            '-f', 'rawvideo', '-pix_fmt', 'rgb24',
+            '-s', f'{width}x{height}', '-r', str(fps),
+            '-i', 'pipe:0',
+        ]
+
+        # 音频输入
+        if audio_path and os.path.exists(audio_path):
+            cmd += ['-ss', str(audio_start)]
+            if audio_duration:
+                cmd += ['-t', str(audio_duration)]
+            cmd += ['-i', audio_path]
+
+        # 视频编码参数
+        cmd += encoder_args
+        cmd += ['-pix_fmt', 'yuv420p']
+
+        # 音频编码
+        if audio_path and os.path.exists(audio_path):
+            cmd += ['-c:a', 'aac', '-b:a', '192k', '-map', '0:v', '-map', '1:a', '-shortest']
+
+        cmd += [output_path]
+        
+        self.process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+    def write_frame(self, frame: np.ndarray):
+        """写入一帧 RGB uint8 数据"""
+        if self.process.stdin:
+            # 确保帧尺寸正确
+            if frame.shape[0] != self.height or frame.shape[1] != self.width:
+                frame = cv2.resize(frame, (self.width, self.height))
+            if frame.shape[2] == 4:
+                frame = frame[:, :, :3]
+            self.process.stdin.write(frame.astype(np.uint8).tobytes())
+
+    def close(self):
+        if self.process.stdin:
+            self.process.stdin.close()
+        self.process.wait()
+        if self.process.returncode != 0:
+            stderr = self.process.stderr.read().decode() if self.process.stderr else ""
+            print(f"[FFmpegWriter] Warning: FFmpeg 返回码 {self.process.returncode}")
+            if stderr:
+                print(f"[FFmpegWriter] stderr: {stderr[:500]}")
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+# ============================================================================
+# 加速渲染 API
+# ============================================================================
+
+def _prepare_bg_frame(bg_path: str, resolution: tuple, is_video: bool = False,
+                      reader: 'VideoFrameReader' = None, time_sec: float = 0) -> np.ndarray:
+    """准备背景帧"""
+    if is_video and reader is not None:
+        frame = reader.get_frame(time_sec)
+        if frame is not None:
+            return cv2.resize(frame, resolution)
+    
+    # 静态图片背景
+    img = cv2.imread(bg_path, cv2.IMREAD_COLOR)
+    if img is None:
+        return np.zeros((resolution[1], resolution[0], 3), dtype=np.uint8)
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    return cv2.resize(img, resolution)
+
+
+def _prepare_video_frame(reader: VideoFrameReader, time_sec: float,
+                         target_size: tuple, crop_rect: tuple = None) -> np.ndarray:
+    """准备谱面视频帧"""
+    frame = reader.get_frame(time_sec)
+    if frame is None:
+        return np.zeros((target_size[1], target_size[0], 3), dtype=np.uint8)
+    
+    if crop_rect:
+        x1, y1, x2, y2 = [int(v) for v in crop_rect]
+        h, w = frame.shape[:2]
+        x1, y1 = max(0, x1), max(0, y1)
+        x2, y2 = min(w, x2), min(h, y2)
+        frame = frame[y1:y2, x1:x2]
+    
+    return cv2.resize(frame, target_size)
+
+
+def _load_image_rgba(path: str) -> np.ndarray:
+    """加载图片为 RGBA numpy 数组"""
+    img = Image.open(path).convert('RGBA')
+    return np.array(img)
+
+
+def _load_image_rgb(path: str, target_size: tuple = None) -> np.ndarray:
+    """加载图片为 RGB numpy 数组"""
+    img = cv2.imread(path, cv2.IMREAD_COLOR)
+    if img is None:
+        if target_size:
+            return np.zeros((target_size[1], target_size[0], 3), dtype=np.uint8)
+        return np.zeros((1080, 1920, 3), dtype=np.uint8)
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    if target_size:
+        img = cv2.resize(img, target_size)
+    return img
+
+
+def compute_video_crop_and_size(game_type: str, video_reader: VideoFrameReader,
+                                resolution: tuple) -> Tuple[tuple, tuple, tuple]:
+    """
+    计算视频的裁剪区域和目标尺寸（与 VideoUtils.edit_game_video_clip 逻辑一致）
+
+    Returns:
+        (target_size, crop_rect_on_resized, video_pos)
+        target_size: (w, h) 缩放后尺寸
+        crop_rect_on_resized: (x1, y1, x2, y2) 在缩放后帧上的裁剪区域，None 表示不裁剪
+        video_pos: (x, y) 在画布上的位置
+    """
+    h_resize_ratio = 0.5 if game_type == "maimai" else 0.667
+    target_h = int(h_resize_ratio * resolution[1])
+    scale = target_h / video_reader.height
+    target_w = int(video_reader.width * scale)
+
+    crop_rect = None
+    if game_type == "maimai":
+        # 裁剪为正方形
+        if abs(target_h - target_w) > 2:
+            center_x = target_w / 2
+            if target_w > target_h:
+                x1 = center_x - target_h / 2
+                x2 = center_x + target_h / 2
+                if x1 < 0:
+                    x1 = 0
+                    x2 = target_h
+                crop_rect = (int(x1), 0, int(x2), target_h)
+            else:
+                center_y = target_h / 2
+                y1 = center_y - target_w / 2
+                y2 = center_y + target_w / 2
+                if y1 < 0:
+                    y1 = 0
+                    y2 = target_w
+                crop_rect = (0, int(y1), target_w, int(y2))
+    elif game_type == "chunithm":
+        target_ar = 16.0 / 9.0
+        current_ar = target_w / target_h if target_h > 0 else target_ar
+        if abs(current_ar - target_ar) / target_ar > 0.03:
+            if current_ar > target_ar:
+                crop_w = int(round(target_h * target_ar))
+                cx1 = int(round((target_w - crop_w) / 2))
+                crop_rect = (cx1, 0, cx1 + crop_w, target_h)
+            else:
+                crop_h = int(round(target_w / target_ar))
+                cy1 = int(round((target_h - crop_h) / 2))
+                crop_rect = (0, cy1, target_w, cy1 + crop_h)
+
+    rel_v_pos_map = {
+        "maimai": (0.092, 0.328),
+        "chunithm": (0.0422, 0.0583)
+    }
+    mul_x, mul_y = rel_v_pos_map.get(game_type, (0.092, 0.328))
+    video_pos = (int(mul_x * resolution[0]), int(mul_y * resolution[1]))
+
+    return (target_w, target_h), crop_rect, video_pos
+
+
+def render_segment_accel(
+    game_type: str,
+    clip_config: dict,
+    style_config: dict,
+    resolution: tuple,
+    output_path: str,
+    fps: int = 30,
+    bitrate: str = "5000k",
+    codec: str = None
+) -> dict:
+    """
+    使用 Taichi GPU + FFmpeg 硬件编码渲染单个视频片段。
+    替代 VideoUtils.create_video_segment() + write_videofile() 的组合。
+    
+    Returns:
+        {"status": "success"|"error", "info": str}
+    """
+    from utils.TaichiAccel import (
+        is_available as ti_available,
+        composite_five_layers,
+        FrameCompositor
+    )
+
+    clip_name = clip_config.get('clip_title_name', 'clip')
+    print(f"[AccelRenderer] 正在渲染: {clip_name} (GPU加速)")
+
+    if not ti_available():
+        return {"status": "error", "info": "Taichi GPU 加速不可用"}
+
+    try:
+        duration = clip_config.get('duration', 10)
+        total_frames = int(duration * fps)
+
+        # === 准备静态资源 ===
+        # 背景
+        default_bg_path = style_config['asset_paths']['content_bg']
+        override_bg = style_config['options'].get('override_content_default_bg', False)
+        using_video_bg = style_config['options'].get('content_use_video_bg', False)
+
+        if override_bg:
+            bg_path = default_bg_path
+        elif 'bg_image' in clip_config and clip_config['bg_image'] and os.path.exists(clip_config.get('bg_image', '')):
+            bg_path = clip_config['bg_image']
+        else:
+            bg_path = default_bg_path
+
+        bg_frame = _load_image_rgb(bg_path, resolution)
+
+        # 背景视频（如果启用）
+        bg_video_reader = None
+        if using_video_bg:
+            bg_video_path = style_config['asset_paths'].get('content_bg_video', None)
+            if bg_video_path and os.path.exists(bg_video_path):
+                bg_video_reader = VideoFrameReader(bg_video_path)
+
+        # 成绩图 (RGBA)
+        if 'main_image' in clip_config and clip_config['main_image'] and os.path.exists(clip_config.get('main_image', '')):
+            score_img = _load_image_rgba(clip_config['main_image'])
+            # 缩放到画布宽度
+            score_scale = resolution[0] / score_img.shape[1]
+            new_h = int(score_img.shape[0] * score_scale)
+            score_img_resized = cv2.resize(score_img, (resolution[0], new_h), interpolation=cv2.INTER_AREA)
+        else:
+            score_img_resized = np.zeros((resolution[1], resolution[0], 4), dtype=np.uint8)
+
+        # 文字图 (RGBA) - 使用 TextRenderer 预渲染
+        from utils.TextRenderer import TextRenderer, TextStyle, LayoutConfig
+        font_path = style_config['asset_paths']['comment_font']
+        text_size = style_config['content_text_style']['font_size']
+        inline_max = style_config['content_text_style']['inline_max_chara']
+        text_area_width = max(400, inline_max * text_size)
+        interline = style_config['content_text_style']['interline']
+        h_align = style_config['content_text_style']['horizontal_align']
+        text_color = style_config['content_text_style']['font_color']
+        enable_stroke = style_config['content_text_style']['enable_stroke']
+        stroke_color = style_config['content_text_style'].get('stroke_color') if enable_stroke else None
+        stroke_width = style_config['content_text_style'].get('stroke_width', 0) if enable_stroke else 0
+
+        text_style = TextStyle(
+            font_path=font_path, font_size=text_size, color=text_color,
+            stroke_color=stroke_color, stroke_width=stroke_width
+        )
+        text_layout = LayoutConfig(
+            width=text_area_width, auto_height=True,
+            padding=(10, 10, 10, 10), line_spacing=interline * 1.2,
+            horizontal_align=h_align, vertical_align="top"
+        )
+        renderer = TextRenderer(text_style, text_layout)
+        text_pil = renderer.render(clip_config.get('text', ''))
+        text_img = np.array(text_pil)
+
+        # 文字位置
+        rel_t_pos_map = {"maimai": (0.54, 0.54), "chunithm": (0.76, 0.227)}
+        tmx, tmy = rel_t_pos_map.get(game_type, (0.54, 0.54))
+        text_pos = (int(tmx * resolution[0]), int(tmy * resolution[1]))
+
+        # === 准备视频源 ===
+        video_reader = None
+        video_pos = (0, 0)
+        target_video_size = (540, 540)
+        crop_rect = None
+
+        if 'video' in clip_config and clip_config['video'] and os.path.exists(clip_config.get('video', '')):
+            video_reader = VideoFrameReader(clip_config['video'])
+            target_video_size, crop_rect, video_pos = compute_video_crop_and_size(
+                game_type, video_reader, resolution
+            )
+        
+        start_time = clip_config.get('start', 0)
+        end_time = clip_config.get('end', start_time + duration)
+
+        # === 提取音频路径 ===
+        audio_path = clip_config.get('video', None)
+        audio_start = start_time
+
+        # === FFmpeg 写入器 ===
+        writer = FFmpegWriter(
+            output_path, resolution[0], resolution[1],
+            fps=fps, codec=codec, bitrate=bitrate,
+            audio_path=audio_path, audio_start=audio_start, audio_duration=duration
+        )
+
+        # === 逐帧渲染（使用 FrameCompositor 预计算静态层）===
+        compositor = FrameCompositor(
+            bg=bg_frame,
+            score_image=score_img_resized,
+            text_image=text_img,
+            video_pos=video_pos,
+            text_pos=text_pos,
+            bg_brightness=0.8,
+            output_size=resolution,
+        )
+
+        for frame_idx in range(total_frames):
+            t = start_time + frame_idx / fps
+
+            # 准备当前视频帧
+            if video_reader:
+                raw_frame = video_reader.get_frame(t)
+                if raw_frame is None:
+                    raw_frame = np.zeros((target_video_size[1], target_video_size[0], 3), dtype=np.uint8)
+                else:
+                    raw_frame = cv2.resize(raw_frame, (target_video_size[0], target_video_size[1]))
+                    if crop_rect:
+                        x1, y1, x2, y2 = crop_rect
+                        x1, y1 = max(0, x1), max(0, y1)
+                        x2 = min(raw_frame.shape[1], x2)
+                        y2 = min(raw_frame.shape[0], y2)
+                        raw_frame = raw_frame[y1:y2, x1:x2]
+                video_frame = raw_frame
+            else:
+                video_frame = np.zeros((target_video_size[1], target_video_size[0], 3), dtype=np.uint8)
+
+            # 动态背景
+            if bg_video_reader:
+                bg_t = t % bg_video_reader.duration if bg_video_reader.duration > 0 else 0
+                current_bg = _prepare_bg_frame(bg_path, resolution, is_video=True,
+                                               reader=bg_video_reader, time_sec=bg_t)
+                compositor.update_bg(current_bg)
+
+            # GPU 快速合成（零拷贝路径）
+            composed = compositor.composite(video_frame)
+
+            writer.write_frame(composed)
+
+        writer.close()
+        if video_reader:
+            video_reader.close()
+        if bg_video_reader:
+            bg_video_reader.close()
+
+        print(f"[AccelRenderer] ✓ 渲染完成: {clip_name}")
+        return {"status": "success", "info": f"GPU加速渲染 {clip_name} 完成"}
+
+    except Exception as e:
+        print(f"[AccelRenderer] Error: {traceback.format_exc()}")
+        return {"status": "error", "info": f"GPU渲染失败: {str(e)}"}
+
+
+def render_info_segment_accel(
+    clip_config: dict,
+    style_config: dict,
+    resolution: tuple,
+    output_path: str,
+    fps: int = 30,
+    bitrate: str = "5000k",
+    codec: str = None
+) -> dict:
+    """
+    使用 FFmpeg 硬件编码渲染开场/结尾信息片段。
+    """
+    from utils.TaichiAccel import is_available as ti_available, multiply_brightness, alpha_composite
+
+    clip_name = clip_config.get('clip_title_name', '片段')
+    print(f"[AccelRenderer] 正在渲染信息片段: {clip_name}")
+
+    try:
+        duration = clip_config.get('duration', 5)
+        total_frames = int(duration * fps)
+
+        # 加载资源
+        intro_text_bg_path = style_config['asset_paths']['intro_text_bg']
+        intro_video_bg_path = style_config['asset_paths']['intro_video_bg']
+        intro_bgm_path = style_config['asset_paths']['intro_bgm']
+
+        text_bg = _load_image_rgba(intro_text_bg_path)
+        text_bg_resized = cv2.resize(text_bg, resolution, interpolation=cv2.INTER_AREA)
+
+        # 背景视频
+        bg_reader = VideoFrameReader(intro_video_bg_path)
+
+        # 渲染文字
+        from utils.TextRenderer import TextRenderer, TextStyle, LayoutConfig
+        font_path = style_config['asset_paths']['comment_font']
+        ts = style_config['intro_text_style']
+
+        text_style = TextStyle(
+            font_path=font_path, font_size=ts['font_size'], color=ts['font_color'],
+            stroke_color=ts.get('stroke_color') if ts['enable_stroke'] else None,
+            stroke_width=ts.get('stroke_width', 0) if ts['enable_stroke'] else 0
+        )
+        text_layout = LayoutConfig(
+            width=max(400, ts['inline_max_chara'] * ts['font_size']),
+            auto_height=True, padding=(10, 10, 10, 10),
+            line_spacing=ts['interline'] * 1.2,
+            horizontal_align=ts['horizontal_align'], vertical_align="top"
+        )
+        renderer = TextRenderer(text_style, text_layout)
+        text_pil = renderer.render(clip_config.get('text', ''))
+        text_img = np.array(text_pil)
+        text_pos = (int(0.16 * resolution[0]), int(0.18 * resolution[1]))
+
+        writer = FFmpegWriter(
+            output_path, resolution[0], resolution[1],
+            fps=fps, codec=codec, bitrate=bitrate,
+            audio_path=intro_bgm_path, audio_start=0, audio_duration=duration
+        )
+
+        for frame_idx in range(total_frames):
+            t = frame_idx / fps
+            bg_t = t % bg_reader.duration if bg_reader.duration > 0 else 0
+            bg_frame = bg_reader.get_frame(bg_t)
+            if bg_frame is None:
+                bg_frame = np.zeros((resolution[1], resolution[0], 3), dtype=np.uint8)
+            else:
+                bg_frame = cv2.resize(bg_frame, resolution)
+
+            if ti_available():
+                bg_frame = multiply_brightness(bg_frame, 0.75)
+                # overlay text_bg (RGBA)
+                composed = alpha_composite(bg_frame if bg_frame.shape[2] == 4 else
+                    np.dstack([bg_frame, np.full(bg_frame.shape[:2], 255, dtype=np.uint8)]),
+                    text_bg_resized, (0, 0))
+                composed = alpha_composite(
+                    np.dstack([composed[:, :, :3], np.full(composed.shape[:2], 255, dtype=np.uint8)]),
+                    text_img, text_pos)
+            else:
+                bg_frame = (bg_frame.astype(np.float32) * 0.75).clip(0, 255).astype(np.uint8)
+                composed = bg_frame
+
+            writer.write_frame(composed[:, :, :3])
+
+        writer.close()
+        bg_reader.close()
+        print(f"[AccelRenderer] ✓ 信息片段渲染完成: {clip_name}")
+        return {"status": "success", "info": f"渲染 {clip_name} 完成"}
+
+    except Exception as e:
+        print(f"[AccelRenderer] Error: {traceback.format_exc()}")
+        return {"status": "error", "info": f"渲染失败: {str(e)}"}
+
+
+def render_all_clips_accel(
+    game_type: str,
+    style_config: dict,
+    main_configs: list,
+    video_output_path: str,
+    video_res: tuple,
+    video_bitrate: str,
+    intro_configs: list = None,
+    ending_configs: list = None,
+    auto_add_transition: bool = True,
+    trans_time: float = 1,
+    force_render: bool = False,
+    fps: int = 30
+):
+    """
+    使用 GPU 加速渲染所有视频片段 —— 替代 VideoUtils.render_all_video_clips()
+    """
+    codec, codec_name = detect_hw_encoder()
+    print(f"[AccelRenderer] 使用编码器: {codec_name}")
+    print(f"[AccelRenderer] 输出路径: {video_output_path}")
+
+    vfile_prefix = 0
+
+    def render_clip(config, prefix, clip_type="content", override_name=None):
+        nonlocal vfile_prefix
+        name = override_name or config.get('clip_title_name', 'clip')
+        name = remove_invalid_chars(name)
+        output_file = os.path.join(video_output_path, f"{prefix}_{name}.mp4")
+
+        if os.path.exists(output_file) and not force_render:
+            print(f"[AccelRenderer] 跳过已存在: {prefix}_{name}.mp4")
+            return
+
+        if clip_type == "content":
+            result = render_segment_accel(
+                game_type, config, style_config, video_res,
+                output_file, fps=fps, bitrate=video_bitrate, codec=codec
+            )
+        else:
+            result = render_info_segment_accel(
+                config, style_config, video_res,
+                output_file, fps=fps, bitrate=video_bitrate, codec=codec
+            )
+
+        if result['status'] == 'error':
+            print(f"[AccelRenderer] Warning: {result['info']}")
+
+    # 开场片段
+    if intro_configs:
+        for config in intro_configs:
+            render_clip(config, vfile_prefix, "info", "INTRO")
+            vfile_prefix += 1
+
+    # 主要片段
+    for config in main_configs:
+        render_clip(config, vfile_prefix, "content")
+        vfile_prefix += 1
+
+    # 结尾片段
+    if ending_configs:
+        for config in ending_configs:
+            render_clip(config, vfile_prefix, "info", "ENDING")
+            vfile_prefix += 1
+
+    print(f"[AccelRenderer] ✓ 所有片段渲染完成 (共 {vfile_prefix} 个)")

--- a/utils/AccelRenderer.py
+++ b/utils/AccelRenderer.py
@@ -263,9 +263,13 @@ def _load_image_rgb(path: str, target_size: tuple = None) -> np.ndarray:
 
 
 def compute_video_crop_and_size(game_type: str, video_reader: VideoFrameReader,
-                                resolution: tuple) -> Tuple[tuple, tuple, tuple]:
+                                resolution: tuple,
+                                visual_center: tuple = None) -> Tuple[tuple, tuple, tuple]:
     """
     计算视频的裁剪区域和目标尺寸（与 VideoUtils.edit_game_video_clip 逻辑一致）
+
+    Args:
+        visual_center: (x, y) 在缩放后帧空间中的视觉中心（来自圆检测），None 使用几何中心
 
     Returns:
         (target_size, crop_rect_on_resized, video_pos)
@@ -282,13 +286,16 @@ def compute_video_crop_and_size(game_type: str, video_reader: VideoFrameReader,
     if game_type == "maimai":
         # 裁剪为正方形
         if abs(target_h - target_w) > 2:
-            center_x = target_w / 2
+            center_x = visual_center[0] if visual_center else target_w / 2
             if target_w > target_h:
                 x1 = center_x - target_h / 2
                 x2 = center_x + target_h / 2
                 if x1 < 0:
                     x1 = 0
                     x2 = target_h
+                elif x2 > target_w:
+                    x2 = target_w
+                    x1 = target_w - target_h
                 crop_rect = (int(x1), 0, int(x2), target_h)
             else:
                 center_y = target_h / 2
@@ -329,7 +336,8 @@ def render_segment_accel(
     output_path: str,
     fps: int = 30,
     bitrate: str = "5000k",
-    codec: str = None
+    codec: str = None,
+    progress_callback=None
 ) -> dict:
     """
     使用 Taichi GPU + FFmpeg 硬件编码渲染单个视频片段。
@@ -425,8 +433,31 @@ def render_segment_accel(
 
         if 'video' in clip_config and clip_config['video'] and os.path.exists(clip_config.get('video', '')):
             video_reader = VideoFrameReader(clip_config['video'])
+
+            # 自动居中对齐：检测视觉中心（maimai 圆形检测）
+            visual_center = None
+            auto_center = clip_config.get('auto_center_align', True)
+            if auto_center and game_type == "maimai":
+                try:
+                    from utils.VisionUtils import find_circle_center
+                    start_time_tmp = clip_config.get('start', 0)
+                    end_time_tmp = clip_config.get('end', start_time_tmp + duration)
+                    mid_time = (start_time_tmp + end_time_tmp) / 2
+                    analysis_frame = video_reader.get_frame(mid_time)
+                    if analysis_frame is not None:
+                        raw_center = find_circle_center(
+                            analysis_frame, debug=False,
+                            name=clip_config.get('clip_title_name', 'clip'))
+                        if raw_center is not None:
+                            # 将原始帧坐标转换到缩放后帧空间
+                            h_resize_ratio = 0.5
+                            scale = int(h_resize_ratio * resolution[1]) / video_reader.height
+                            visual_center = (raw_center[0] * scale, raw_center[1] * scale)
+                except Exception as e:
+                    print(f"[AccelRenderer] Warning: 自动居中检测失败: {e}")
+
             target_video_size, crop_rect, video_pos = compute_video_crop_and_size(
-                game_type, video_reader, resolution
+                game_type, video_reader, resolution, visual_center=visual_center
             )
         
         start_time = clip_config.get('start', 0)
@@ -486,7 +517,9 @@ def render_segment_accel(
 
             writer.write_frame(composed)
 
-        writer.close()
+            # 节流的进度回调（每 30 帧或最后一帧）
+            if progress_callback and (frame_idx % 30 == 0 or frame_idx == total_frames - 1):
+                progress_callback(frame_idx + 1, total_frames, clip_name)
         if video_reader:
             video_reader.close()
         if bg_video_reader:
@@ -507,7 +540,8 @@ def render_info_segment_accel(
     output_path: str,
     fps: int = 30,
     bitrate: str = "5000k",
-    codec: str = None
+    codec: str = None,
+    progress_callback=None
 ) -> dict:
     """
     使用 FFmpeg 硬件编码渲染开场/结尾信息片段。
@@ -613,7 +647,8 @@ def render_info_segment_accel(
 
             writer.write_frame(composed[:, :, :3])
 
-        writer.close()
+            if progress_callback and (frame_idx % 30 == 0 or frame_idx == total_frames - 1):
+                progress_callback(frame_idx + 1, total_frames, clip_name)
         bg_reader.close()
         print(f"[AccelRenderer] ✓ 信息片段渲染完成: {clip_name}")
         return {"status": "success", "info": f"渲染 {clip_name} 完成"}
@@ -635,16 +670,29 @@ def render_all_clips_accel(
     auto_add_transition: bool = True,
     trans_time: float = 1,
     force_render: bool = False,
-    fps: int = 30
+    fps: int = 30,
+    progress_callback=None
 ):
     """
     使用 GPU 加速渲染所有视频片段 —— 替代 VideoUtils.render_all_video_clips()
+    progress_callback: (clip_index, total_clips, frame, total_frames, clip_name) -> None
     """
     codec, codec_name = detect_hw_encoder()
     print(f"[AccelRenderer] 使用编码器: {codec_name}")
     print(f"[AccelRenderer] 输出路径: {video_output_path}")
 
+    total_clips = len(main_configs) + len(intro_configs or []) + len(ending_configs or [])
+    clip_index = [0]  # 使用列表以便在闭包中修改
     vfile_prefix = 0
+
+    def _make_frame_callback():
+        """为当前片段创建帧级回调"""
+        idx = clip_index[0]
+        if progress_callback is None:
+            return None
+        def cb(frame, total_frames, clip_name):
+            progress_callback(idx, total_clips, frame, total_frames, clip_name)
+        return cb
 
     def render_clip(config, prefix, clip_type="content", override_name=None):
         nonlocal vfile_prefix
@@ -654,21 +702,26 @@ def render_all_clips_accel(
 
         if os.path.exists(output_file) and not force_render:
             print(f"[AccelRenderer] 跳过已存在: {prefix}_{name}.mp4")
+            clip_index[0] += 1
             return
 
+        frame_cb = _make_frame_callback()
         if clip_type == "content":
             result = render_segment_accel(
                 game_type, config, style_config, video_res,
-                output_file, fps=fps, bitrate=video_bitrate, codec=codec
+                output_file, fps=fps, bitrate=video_bitrate, codec=codec,
+                progress_callback=frame_cb
             )
         else:
             result = render_info_segment_accel(
                 config, style_config, video_res,
-                output_file, fps=fps, bitrate=video_bitrate, codec=codec
+                output_file, fps=fps, bitrate=video_bitrate, codec=codec,
+                progress_callback=frame_cb
             )
 
         if result['status'] == 'error':
             print(f"[AccelRenderer] Warning: {result['info']}")
+        clip_index[0] += 1
 
     # 开场片段
     if intro_configs:

--- a/utils/AccelRenderer.py
+++ b/utils/AccelRenderer.py
@@ -78,7 +78,7 @@ def get_ffmpeg_encoder_args(codec: str, bitrate: str = "5000k") -> list:
 # ============================================================================
 
 class VideoFrameReader:
-    """使用 OpenCV 读取视频帧"""
+    """使用 OpenCV 读取视频帧，支持顺序读取模式避免随机 seek 开销"""
 
     def __init__(self, video_path: str):
         self.path = video_path
@@ -90,14 +90,33 @@ class VideoFrameReader:
         self.width = int(self.cap.get(cv2.CAP_PROP_FRAME_WIDTH))
         self.height = int(self.cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
         self.duration = self.frame_count / self.fps if self.fps > 0 else 0
+        self._current_pos = 0
 
-    def get_frame(self, time_sec: float) -> Optional[np.ndarray]:
-        """获取指定时间点的帧 (RGB uint8)"""
+    def seek_to(self, time_sec: float):
+        """定位到指定时间点，用于开始顺序读取前的初始定位"""
         frame_idx = int(time_sec * self.fps)
         frame_idx = max(0, min(frame_idx, self.frame_count - 1))
         self.cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+        self._current_pos = frame_idx
+
+    def read_next(self) -> Optional[np.ndarray]:
+        """顺序读取下一帧 (RGB uint8)，避免随机 seek 开销"""
         ret, frame = self.cap.read()
         if ret:
+            self._current_pos += 1
+            return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        return None
+
+    def get_frame(self, time_sec: float) -> Optional[np.ndarray]:
+        """获取指定时间点的帧 (RGB uint8)，需要随机访问时使用"""
+        frame_idx = int(time_sec * self.fps)
+        frame_idx = max(0, min(frame_idx, self.frame_count - 1))
+        if frame_idx != self._current_pos:
+            self.cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+            self._current_pos = frame_idx
+        ret, frame = self.cap.read()
+        if ret:
+            self._current_pos += 1
             return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         return None
 
@@ -534,16 +553,32 @@ def render_info_segment_accel(
         text_img = np.array(text_pil)
         text_pos = (int(0.16 * resolution[0]), int(0.18 * resolution[1]))
 
+        # 预拆分静态 RGBA 层（循环外一次性完成）
+        text_bg_rgb = text_bg_resized[:, :, :3].astype(np.float32)
+        text_bg_mask = text_bg_resized[:, :, 3].astype(np.float32) / 255.0 if text_bg_resized.shape[2] == 4 else None
+        text_img_rgb = text_img[:, :, :3].astype(np.float32)
+        text_img_mask = text_img[:, :, 3].astype(np.float32) / 255.0 if text_img.shape[2] == 4 else None
+        tx, ty = text_pos
+
         writer = FFmpegWriter(
             output_path, resolution[0], resolution[1],
             fps=fps, codec=codec, bitrate=bitrate,
             audio_path=intro_bgm_path, audio_start=0, audio_duration=duration
         )
 
+        # 使用顺序读取模式
+        bg_reader.seek_to(0)
+
         for frame_idx in range(total_frames):
             t = frame_idx / fps
             bg_t = t % bg_reader.duration if bg_reader.duration > 0 else 0
-            bg_frame = bg_reader.get_frame(bg_t)
+            # 循环播放背景视频时需要 seek 回起始点
+            if frame_idx > 0 and bg_t < (frame_idx - 1) / fps % bg_reader.duration:
+                bg_reader.seek_to(bg_t)
+            bg_frame = bg_reader.read_next()
+            if bg_frame is None:
+                bg_reader.seek_to(bg_t)
+                bg_frame = bg_reader.read_next()
             if bg_frame is None:
                 bg_frame = np.zeros((resolution[1], resolution[0], 3), dtype=np.uint8)
             else:
@@ -551,7 +586,6 @@ def render_info_segment_accel(
 
             if ti_available():
                 bg_frame = multiply_brightness(bg_frame, 0.75)
-                # overlay text_bg (RGBA)
                 composed = alpha_composite(bg_frame if bg_frame.shape[2] == 4 else
                     np.dstack([bg_frame, np.full(bg_frame.shape[:2], 255, dtype=np.uint8)]),
                     text_bg_resized, (0, 0))
@@ -559,8 +593,23 @@ def render_info_segment_accel(
                     np.dstack([composed[:, :, :3], np.full(composed.shape[:2], 255, dtype=np.uint8)]),
                     text_img, text_pos)
             else:
-                bg_frame = (bg_frame.astype(np.float32) * 0.75).clip(0, 255).astype(np.uint8)
-                composed = bg_frame
+                # CPU fallback: 完整合成（暗化背景 + text_bg + text）
+                composed = (bg_frame.astype(np.float32) * 0.75).clip(0, 255)
+                # 叠加 text_bg
+                if text_bg_mask is not None:
+                    h, w = text_bg_rgb.shape[:2]
+                    mask3 = text_bg_mask[:, :, np.newaxis]
+                    composed[:h, :w] = composed[:h, :w] * (1 - mask3) + text_bg_rgb * mask3
+                # 叠加 text
+                if text_img_mask is not None:
+                    th, tw = text_img_rgb.shape[:2]
+                    y1, y2 = ty, min(ty + th, composed.shape[0])
+                    x1, x2 = tx, min(tx + tw, composed.shape[1])
+                    sh, sw = y2 - y1, x2 - x1
+                    if sh > 0 and sw > 0:
+                        mask3 = text_img_mask[:sh, :sw, np.newaxis]
+                        composed[y1:y2, x1:x2] = composed[y1:y2, x1:x2] * (1 - mask3) + text_img_rgb[:sh, :sw] * mask3
+                composed = composed.clip(0, 255).astype(np.uint8)
 
             writer.write_frame(composed[:, :, :3])
 

--- a/utils/TaichiAccel.py
+++ b/utils/TaichiAccel.py
@@ -57,7 +57,11 @@ def init_taichi(arch=None):
         try:
             ti.init(arch=backend_arch)
             # Taichi 可能静默回退到其他后端，检查实际使用的后端
-            actual_arch = ti.lang.impl.current_cfg().arch
+            # 注意：current_cfg() 是 Taichi 内部 API，通过 try/except 保护兼容性
+            try:
+                actual_arch = ti.lang.impl.current_cfg().arch
+            except AttributeError:
+                actual_arch = backend_arch  # API 变更时假设未回退
             if actual_arch != backend_arch and backend_arch != ti.cpu:
                 ti.reset()
                 continue
@@ -525,8 +529,12 @@ class FrameCompositor:
         self._out_buf = np.zeros((self.out_h, self.out_w, 3), dtype=np.uint8)
 
     def update_bg(self, bg: np.ndarray):
-        """动态背景（视频背景）时更新 bg"""
-        self.bg_f = bg[:, :, :3].astype(np.float32)
+        """动态背景（视频背景）时更新 bg，复用缓冲区避免每帧分配"""
+        src = bg[:, :, :3]
+        if self.bg_f.shape[:2] == src.shape[:2]:
+            np.copyto(self.bg_f, src, casting='unsafe')
+        else:
+            self.bg_f = src.astype(np.float32)
 
     def composite(self, video_frame: np.ndarray) -> np.ndarray:
         """

--- a/utils/TaichiAccel.py
+++ b/utils/TaichiAccel.py
@@ -1,0 +1,551 @@
+"""
+TaichiAccel.py - Taichi GPU 加速模块
+
+使用 Taichi 实现 GPU 加速的图像合成操作，替代 MoviePy 逐帧 CPU 处理。
+支持自动选择最佳 GPU 后端（CUDA > Vulkan > Metal > OpenGL > CPU）。
+"""
+
+import numpy as np
+import traceback
+
+try:
+    import taichi as ti
+    TAICHI_AVAILABLE = True
+except ImportError:
+    TAICHI_AVAILABLE = False
+
+_ti_initialized = False
+
+
+def init_taichi(arch=None):
+    """
+    初始化 Taichi 运行时，自动选择最佳 GPU 后端。
+    如果 GPU 不可用则回退到 CPU。
+    """
+    global _ti_initialized
+    if _ti_initialized:
+        return True
+    if not TAICHI_AVAILABLE:
+        print("[TaichiAccel] Warning: taichi 未安装，GPU 加速不可用")
+        return False
+
+    if arch is not None:
+        try:
+            ti.init(arch=arch)
+            _ti_initialized = True
+            print(f"[TaichiAccel] 已使用指定后端初始化: {arch}")
+            return True
+        except Exception:
+            pass
+
+    # 按优先级尝试 GPU 后端 (macOS 上 Metal 优先于 Vulkan)
+    import platform
+    if platform.system() == "Darwin":
+        backends = [
+            (ti.metal, "Metal"),
+            (ti.vulkan, "Vulkan"),
+            (ti.cpu, "CPU"),
+        ]
+    else:
+        backends = [
+            (ti.cuda, "CUDA"),
+            (ti.vulkan, "Vulkan"),
+            (ti.opengl, "OpenGL"),
+            (ti.cpu, "CPU"),
+        ]
+    for backend_arch, name in backends:
+        try:
+            ti.init(arch=backend_arch)
+            # Taichi 可能静默回退到其他后端，检查实际使用的后端
+            actual_arch = ti.lang.impl.current_cfg().arch
+            if actual_arch != backend_arch and backend_arch != ti.cpu:
+                ti.reset()
+                continue
+            actual_name = str(actual_arch).replace("Arch.", "").upper()
+            _ti_initialized = True
+            print(f"[TaichiAccel] ✓ 使用 {actual_name} 后端初始化成功")
+            return True
+        except Exception:
+            try:
+                ti.reset()
+            except Exception:
+                pass
+            continue
+
+    print("[TaichiAccel] Warning: 所有后端均初始化失败")
+    return False
+
+
+def is_available():
+    """检查 Taichi 加速是否可用"""
+    return TAICHI_AVAILABLE and _ti_initialized
+
+
+# ============================================================================
+# Taichi Kernels
+# ============================================================================
+
+if TAICHI_AVAILABLE:
+
+    # ------------------------------------------------------------------
+    # 核心原则：所有 kernel 的最外层 for 遍历每个像素 (i,j)，
+    # Taichi 自动将其映射为 GPU thread，保证逐像素并行。
+    # 蒙版(mask)作为独立 2D ndarray 传入，避免 kernel 内部动态
+    # shape 分支，确保 warp 内所有线程走同一条指令路径。
+    # ------------------------------------------------------------------
+
+    @ti.kernel
+    def _alpha_composite_kernel(
+        base: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        overlay_rgb: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        mask: ti.types.ndarray(dtype=ti.f32, ndim=2),
+        out: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        ox: ti.i32, oy: ti.i32,
+        overlay_h: ti.i32, overlay_w: ti.i32,
+        base_h: ti.i32, base_w: ti.i32
+    ):
+        """逐像素并行 alpha 混合：mask 为独立 2D 蒙版 [0,1]"""
+        for i, j in ti.ndrange(base_h, base_w):
+            si = i - oy
+            sj = j - ox
+            if 0 <= si < overlay_h and 0 <= sj < overlay_w:
+                a = mask[si, sj]
+                inv_a = 1.0 - a
+                for c in ti.static(range(3)):
+                    out[i, j, c] = base[i, j, c] * inv_a + overlay_rgb[si, sj, c] * a
+            else:
+                for c in ti.static(range(3)):
+                    out[i, j, c] = base[i, j, c]
+
+    @ti.kernel
+    def _multiply_brightness_kernel(
+        src: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        out: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        factor: ti.f32,
+        h: ti.i32, w: ti.i32
+    ):
+        """逐像素并行亮度调整"""
+        for i, j in ti.ndrange(h, w):
+            for c in ti.static(range(3)):
+                out[i, j, c] = ti.min(src[i, j, c] * factor, 255.0)
+
+    @ti.kernel
+    def _crossfade_kernel(
+        frame_a: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        frame_b: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        out: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        alpha: ti.f32,
+        h: ti.i32, w: ti.i32
+    ):
+        """逐像素并行交叉淡入淡出"""
+        for i, j in ti.ndrange(h, w):
+            inv_alpha = 1.0 - alpha
+            for c in ti.static(range(3)):
+                out[i, j, c] = frame_a[i, j, c] * inv_alpha + frame_b[i, j, c] * alpha
+
+    @ti.kernel
+    def _resize_bilinear_kernel(
+        src: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        out: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        src_h: ti.i32, src_w: ti.i32,
+        dst_h: ti.i32, dst_w: ti.i32
+    ):
+        """逐像素并行双线性插值缩放 (固定 3 通道)"""
+        for i, j in ti.ndrange(dst_h, dst_w):
+            src_y = ti.cast(i, ti.f32) * ti.cast(src_h, ti.f32) / ti.cast(dst_h, ti.f32)
+            src_x = ti.cast(j, ti.f32) * ti.cast(src_w, ti.f32) / ti.cast(dst_w, ti.f32)
+
+            y0 = ti.cast(ti.floor(src_y), ti.i32)
+            x0 = ti.cast(ti.floor(src_x), ti.i32)
+            y1 = ti.min(y0 + 1, src_h - 1)
+            x1 = ti.min(x0 + 1, src_w - 1)
+
+            fy = src_y - ti.cast(y0, ti.f32)
+            fx = src_x - ti.cast(x0, ti.f32)
+
+            w00 = (1.0 - fx) * (1.0 - fy)
+            w01 = fx * (1.0 - fy)
+            w10 = (1.0 - fx) * fy
+            w11 = fx * fy
+
+            for c in ti.static(range(3)):
+                out[i, j, c] = (src[y0, x0, c] * w00 +
+                                src[y0, x1, c] * w01 +
+                                src[y1, x0, c] * w10 +
+                                src[y1, x1, c] * w11)
+
+    @ti.kernel
+    def _resize_bilinear_4ch_kernel(
+        src: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        out: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        src_h: ti.i32, src_w: ti.i32,
+        dst_h: ti.i32, dst_w: ti.i32
+    ):
+        """逐像素并行双线性插值缩放 (固定 4 通道 RGBA)"""
+        for i, j in ti.ndrange(dst_h, dst_w):
+            src_y = ti.cast(i, ti.f32) * ti.cast(src_h, ti.f32) / ti.cast(dst_h, ti.f32)
+            src_x = ti.cast(j, ti.f32) * ti.cast(src_w, ti.f32) / ti.cast(dst_w, ti.f32)
+
+            y0 = ti.cast(ti.floor(src_y), ti.i32)
+            x0 = ti.cast(ti.floor(src_x), ti.i32)
+            y1 = ti.min(y0 + 1, src_h - 1)
+            x1 = ti.min(x0 + 1, src_w - 1)
+
+            fy = src_y - ti.cast(y0, ti.f32)
+            fx = src_x - ti.cast(x0, ti.f32)
+
+            w00 = (1.0 - fx) * (1.0 - fy)
+            w01 = fx * (1.0 - fy)
+            w10 = (1.0 - fx) * fy
+            w11 = fx * fy
+
+            for c in ti.static(range(4)):
+                out[i, j, c] = (src[y0, x0, c] * w00 +
+                                src[y0, x1, c] * w01 +
+                                src[y1, x0, c] * w10 +
+                                src[y1, x1, c] * w11)
+
+    @ti.kernel
+    def _five_layer_composite_kernel(
+        bg: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        video: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        score_rgb: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        score_mask: ti.types.ndarray(dtype=ti.f32, ndim=2),
+        text_rgb: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        text_mask: ti.types.ndarray(dtype=ti.f32, ndim=2),
+        out: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        bg_brightness: ti.f32,
+        vid_x: ti.i32, vid_y: ti.i32,
+        vid_h: ti.i32, vid_w: ti.i32,
+        score_h: ti.i32, score_w: ti.i32,
+        text_x: ti.i32, text_y: ti.i32,
+        text_h: ti.i32, text_w: ti.i32,
+        out_h: ti.i32, out_w: ti.i32
+    ):
+        """
+        逐像素并行 5 层合成内核。
+        蒙版(score_mask, text_mask)为独立 2D 数组，无动态分支。
+        层顺序: black → bg (dimmed) → video → score → text
+        """
+        for i, j in ti.ndrange(out_h, out_w):
+            # Layer 1: 背景 (dimmed)
+            r = bg[i, j, 0] * bg_brightness
+            g = bg[i, j, 1] * bg_brightness
+            b = bg[i, j, 2] * bg_brightness
+
+            # Layer 2: 谱面视频 (直接覆盖，无 alpha)
+            vi = i - vid_y
+            vj = j - vid_x
+            if 0 <= vi < vid_h and 0 <= vj < vid_w:
+                r = video[vi, vj, 0]
+                g = video[vi, vj, 1]
+                b = video[vi, vj, 2]
+
+            # Layer 3: 成绩图 (mask 混合)
+            if i < score_h and j < score_w:
+                sa = score_mask[i, j]
+                inv_sa = 1.0 - sa
+                r = r * inv_sa + score_rgb[i, j, 0] * sa
+                g = g * inv_sa + score_rgb[i, j, 1] * sa
+                b = b * inv_sa + score_rgb[i, j, 2] * sa
+
+            # Layer 4: 文字 (mask 混合)
+            ti_i = i - text_y
+            tj_j = j - text_x
+            if 0 <= ti_i < text_h and 0 <= tj_j < text_w:
+                ta = text_mask[ti_i, tj_j]
+                inv_ta = 1.0 - ta
+                r = r * inv_ta + text_rgb[ti_i, tj_j, 0] * ta
+                g = g * inv_ta + text_rgb[ti_i, tj_j, 1] * ta
+                b = b * inv_ta + text_rgb[ti_i, tj_j, 2] * ta
+
+            out[i, j, 0] = ti.min(r, 255.0)
+            out[i, j, 1] = ti.min(g, 255.0)
+            out[i, j, 2] = ti.min(b, 255.0)
+
+    @ti.kernel
+    def _five_layer_fast_kernel(
+        bg: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        video_u8: ti.types.ndarray(dtype=ti.u8, ndim=3),
+        score_rgb: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        score_mask: ti.types.ndarray(dtype=ti.f32, ndim=2),
+        text_rgb: ti.types.ndarray(dtype=ti.f32, ndim=3),
+        text_mask: ti.types.ndarray(dtype=ti.f32, ndim=2),
+        out: ti.types.ndarray(dtype=ti.u8, ndim=3),
+        bg_brightness: ti.f32,
+        vid_x: ti.i32, vid_y: ti.i32,
+        vid_h: ti.i32, vid_w: ti.i32,
+        score_h: ti.i32, score_w: ti.i32,
+        text_x: ti.i32, text_y: ti.i32,
+        text_h: ti.i32, text_w: ti.i32,
+        out_h: ti.i32, out_w: ti.i32
+    ):
+        """
+        零拷贝快速路径：video 输入为 uint8，输出直接写 uint8，
+        跳过 Python 端 float32 转换和 np.clip，减少内存带宽开销。
+        """
+        for i, j in ti.ndrange(out_h, out_w):
+            r = bg[i, j, 0] * bg_brightness
+            g = bg[i, j, 1] * bg_brightness
+            b = bg[i, j, 2] * bg_brightness
+
+            vi = i - vid_y
+            vj = j - vid_x
+            if 0 <= vi < vid_h and 0 <= vj < vid_w:
+                r = ti.cast(video_u8[vi, vj, 0], ti.f32)
+                g = ti.cast(video_u8[vi, vj, 1], ti.f32)
+                b = ti.cast(video_u8[vi, vj, 2], ti.f32)
+
+            if i < score_h and j < score_w:
+                sa = score_mask[i, j]
+                inv_sa = 1.0 - sa
+                r = r * inv_sa + score_rgb[i, j, 0] * sa
+                g = g * inv_sa + score_rgb[i, j, 1] * sa
+                b = b * inv_sa + score_rgb[i, j, 2] * sa
+
+            ti_i = i - text_y
+            tj_j = j - text_x
+            if 0 <= ti_i < text_h and 0 <= tj_j < text_w:
+                ta = text_mask[ti_i, tj_j]
+                inv_ta = 1.0 - ta
+                r = r * inv_ta + text_rgb[ti_i, tj_j, 0] * ta
+                g = g * inv_ta + text_rgb[ti_i, tj_j, 1] * ta
+                b = b * inv_ta + text_rgb[ti_i, tj_j, 2] * ta
+
+            out[i, j, 0] = ti.cast(ti.min(ti.max(r, 0.0), 255.0), ti.u8)
+            out[i, j, 1] = ti.cast(ti.min(ti.max(g, 0.0), 255.0), ti.u8)
+            out[i, j, 2] = ti.cast(ti.min(ti.max(b, 0.0), 255.0), ti.u8)
+
+
+# ============================================================================
+# Python API Wrappers
+# ============================================================================
+
+# ============================================================================
+# 辅助函数：从 RGBA 图像拆分 RGB + mask
+# ============================================================================
+
+def _split_rgba(image: np.ndarray):
+    """
+    将 RGBA 图像拆分为 RGB (H,W,3) float32 和 mask (H,W) float32 [0,1]。
+    如果输入是 RGB (无 alpha)，返回 RGB + 全 1 mask（完全不透明）。
+    """
+    if image.ndim == 3 and image.shape[2] == 4:
+        rgb = image[:, :, :3].astype(np.float32)
+        mask = image[:, :, 3].astype(np.float32) / 255.0
+    elif image.ndim == 3 and image.shape[2] == 3:
+        rgb = image.astype(np.float32)
+        mask = np.ones((image.shape[0], image.shape[1]), dtype=np.float32)
+    else:
+        raise ValueError(f"Unsupported image shape: {image.shape}")
+    return rgb, mask
+
+
+def alpha_composite(base: np.ndarray, overlay: np.ndarray,
+                    position: tuple = (0, 0)) -> np.ndarray:
+    """
+    GPU 加速的 alpha 混合。蒙版自动从 RGBA 第4通道拆分。
+    
+    Args:
+        base: 底图 (H, W, 3|4) uint8
+        overlay: 叠加图 (H, W, 3|4) uint8, 支持 RGBA alpha 通道
+        position: (x, y) 叠加位置
+    Returns:
+        合成结果 (H, W, 3) uint8
+    """
+    if not is_available():
+        raise RuntimeError("Taichi 未初始化")
+
+    h, w = base.shape[:2]
+    oh, ow = overlay.shape[:2]
+    ox, oy = int(position[0]), int(position[1])
+
+    base_f = base[:, :, :3].astype(np.float32)
+    overlay_rgb, mask = _split_rgba(overlay)
+    out = np.zeros((h, w, 3), dtype=np.float32)
+
+    _alpha_composite_kernel(base_f, overlay_rgb, mask, out, ox, oy, oh, ow, h, w)
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def multiply_brightness(image: np.ndarray, factor: float) -> np.ndarray:
+    """GPU 加速的亮度调整"""
+    if not is_available():
+        raise RuntimeError("Taichi 未初始化")
+
+    h, w = image.shape[:2]
+    src = image.astype(np.float32)
+    out = np.zeros_like(src)
+    _multiply_brightness_kernel(src, out, factor, h, w)
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def resize_bilinear(image: np.ndarray, target_size: tuple) -> np.ndarray:
+    """
+    GPU 加速的双线性插值缩放。
+
+    Args:
+        image: 输入图像 (H, W, 3|4) uint8
+        target_size: (target_width, target_height)
+    Returns:
+        缩放后图像 uint8，通道数与输入一致
+    """
+    if not is_available():
+        raise RuntimeError("Taichi 未初始化")
+
+    dst_w, dst_h = target_size
+    src_h, src_w = image.shape[:2]
+    channels = image.shape[2] if image.ndim == 3 else 3
+
+    src = image.astype(np.float32)
+    if src.ndim == 2:
+        src = np.stack([src, src, src], axis=-1)
+        channels = 3
+
+    if channels == 4:
+        out = np.zeros((dst_h, dst_w, 4), dtype=np.float32)
+        _resize_bilinear_4ch_kernel(src, out, src_h, src_w, dst_h, dst_w)
+    else:
+        src = src[:, :, :3]
+        out = np.zeros((dst_h, dst_w, 3), dtype=np.float32)
+        _resize_bilinear_kernel(src, out, src_h, src_w, dst_h, dst_w)
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def crossfade(frame_a: np.ndarray, frame_b: np.ndarray, alpha: float) -> np.ndarray:
+    """GPU 加速的交叉淡入淡出混合"""
+    if not is_available():
+        raise RuntimeError("Taichi 未初始化")
+
+    h, w = frame_a.shape[:2]
+    a_f = frame_a.astype(np.float32)
+    b_f = frame_b.astype(np.float32)
+    out = np.zeros_like(a_f)
+    _crossfade_kernel(a_f, b_f, out, alpha, h, w)
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def composite_five_layers(
+    bg: np.ndarray,
+    video_frame: np.ndarray,
+    score_image: np.ndarray,
+    text_image: np.ndarray,
+    video_pos: tuple,
+    text_pos: tuple,
+    bg_brightness: float = 0.8,
+    output_size: tuple = (1920, 1080)
+) -> np.ndarray:
+    """
+    GPU 加速的 5 层合成 —— 单次 kernel 调用替代 MoviePy CompositeVideoClip。
+    
+    蒙版处理策略：RGBA 图像的第4通道在 Python 端拆分为独立 2D mask 数组，
+    kernel 内部不做任何 shape 动态分支，确保所有像素走完全相同的指令路径，
+    最大化 GPU warp/SIMD 利用率。
+
+    层顺序: black → bg (dimmed) → video → score_image (mask) → text (mask)
+    
+    Args:
+        bg: 背景图/帧 (H, W, 3) uint8
+        video_frame: 谱面视频帧 (H, W, 3) uint8
+        score_image: 成绩图 (H, W, 4) uint8 RGBA
+        text_image: 文字图 (H, W, 4) uint8 RGBA
+        video_pos: (x, y) 视频位置
+        text_pos: (x, y) 文字位置
+        bg_brightness: 背景亮度系数
+        output_size: (width, height) 输出尺寸
+    Returns:
+        合成帧 (H, W, 3) uint8 RGB
+    """
+    if not is_available():
+        raise RuntimeError("Taichi 未初始化")
+
+    out_w, out_h = output_size
+    vid_x, vid_y = int(video_pos[0]), int(video_pos[1])
+    text_x, text_y = int(text_pos[0]), int(text_pos[1])
+    vid_h, vid_w = video_frame.shape[:2]
+
+    bg_f = bg[:, :, :3].astype(np.float32)
+    video_f = video_frame[:, :, :3].astype(np.float32)
+
+    # 拆分蒙版：RGB + mask 分离传入 kernel
+    score_rgb, score_mask = _split_rgba(score_image)
+    text_rgb, text_mask = _split_rgba(text_image)
+    score_h, score_w = score_rgb.shape[:2]
+    text_h, text_w = text_rgb.shape[:2]
+
+    out = np.zeros((out_h, out_w, 3), dtype=np.float32)
+
+    _five_layer_composite_kernel(
+        bg_f, video_f, score_rgb, score_mask, text_rgb, text_mask, out,
+        bg_brightness,
+        vid_x, vid_y, vid_h, vid_w,
+        score_h, score_w,
+        text_x, text_y, text_h, text_w,
+        out_h, out_w
+    )
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+class FrameCompositor:
+    """
+    高性能帧合成器：预计算静态层，复用缓冲区。
+
+    一个视频片段内 score_image / text_image / bg(静态背景) 不会逐帧变化，
+    因此在构造时一次性完成 RGBA 拆分和 float32 转换，帧循环里只传入
+    变化的 video_frame (uint8)，由 _five_layer_fast_kernel 在 GPU 内部
+    做 u8→f32 转换，避免 Python 端每帧 ~20MB 的内存拷贝。
+    """
+
+    def __init__(
+        self,
+        bg: np.ndarray,
+        score_image: np.ndarray,
+        text_image: np.ndarray,
+        video_pos: tuple,
+        text_pos: tuple,
+        bg_brightness: float = 0.8,
+        output_size: tuple = (1920, 1080),
+    ):
+        if not is_available():
+            raise RuntimeError("Taichi 未初始化")
+
+        self.out_w, self.out_h = output_size
+        self.vid_x, self.vid_y = int(video_pos[0]), int(video_pos[1])
+        self.text_x, self.text_y = int(text_pos[0]), int(text_pos[1])
+        self.bg_brightness = float(bg_brightness)
+
+        # 静态层预计算（一次性）
+        self.bg_f = bg[:, :, :3].astype(np.float32)
+        self.score_rgb, self.score_mask = _split_rgba(score_image)
+        self.text_rgb, self.text_mask = _split_rgba(text_image)
+        self.score_h, self.score_w = self.score_rgb.shape[:2]
+        self.text_h, self.text_w = self.text_rgb.shape[:2]
+
+        # 输出缓冲区复用
+        self._out_buf = np.zeros((self.out_h, self.out_w, 3), dtype=np.uint8)
+
+    def update_bg(self, bg: np.ndarray):
+        """动态背景（视频背景）时更新 bg"""
+        self.bg_f = bg[:, :, :3].astype(np.float32)
+
+    def composite(self, video_frame: np.ndarray) -> np.ndarray:
+        """
+        合成一帧。video_frame 为 uint8 RGB，直接传入 GPU kernel。
+        返回的 ndarray 是内部缓冲区的引用，下次调用会被覆盖。
+        如果需要保留，请调用方自行 .copy()。
+        """
+        vid_h, vid_w = video_frame.shape[:2]
+        video_u8 = np.ascontiguousarray(video_frame[:, :, :3])
+
+        _five_layer_fast_kernel(
+            self.bg_f, video_u8,
+            self.score_rgb, self.score_mask,
+            self.text_rgb, self.text_mask,
+            self._out_buf,
+            self.bg_brightness,
+            self.vid_x, self.vid_y, vid_h, vid_w,
+            self.score_h, self.score_w,
+            self.text_x, self.text_y, self.text_h, self.text_w,
+            self.out_h, self.out_w,
+        )
+        return self._out_buf

--- a/utils/VideoUtils.py
+++ b/utils/VideoUtils.py
@@ -813,7 +813,7 @@ def render_all_video_clips(game_type: str, style_config: dict, main_configs: lis
                            video_output_path: str, video_res: tuple, video_bitrate: str,
                            intro_configs: list = None, ending_configs: list = None,
                            auto_add_transition=True, trans_time=1, force_render=False,
-                           use_gpu_accel: bool = None):
+                           use_gpu_accel: bool = None, progress_callback=None):
     """ 渲染所有视频片段，并按照clip_title_name输出到指定路径文件。
         当 use_gpu_accel=True 时使用 Taichi GPU + FFmpeg 硬件编码加速。
         当 use_gpu_accel=None 时从 global_config 读取配置。
@@ -843,7 +843,8 @@ def render_all_video_clips(game_type: str, style_config: dict, main_configs: lis
                     ending_configs=ending_configs,
                     auto_add_transition=auto_add_transition,
                     trans_time=trans_time,
-                    force_render=force_render
+                    force_render=force_render,
+                    progress_callback=progress_callback
                 )
                 return
             else:
@@ -935,7 +936,7 @@ def render_complete_full_video(
         intro_configs: list=None, ending_configs: list=None,
         video_res: tuple = (1920, 1080), video_bitrate: str = "4000k",
         video_trans_enable: bool = True, video_trans_time: float = 1.0, full_last_clip: bool = False,
-        use_gpu_accel: bool = None):
+        use_gpu_accel: bool = None, progress_callback=None):
     """ 根据完整配置合成完整视频，并保存到指定路径的文件。
         当 use_gpu_accel=True 时，先用 GPU 加速渲染所有片段，再用 FFmpeg 拼接。
     """
@@ -965,16 +966,19 @@ def render_complete_full_video(
                     ending_configs=ending_configs,
                     auto_add_transition=video_trans_enable,
                     trans_time=video_trans_time,
-                    force_render=force_render
+                    force_render=True,
+                    progress_callback=progress_callback
                 )
-                # 第二步：使用 FFmpeg 直接拼接（速度快，无需再次编码）
+                # 第二步：使用 FFmpeg 拼接（支持转场效果）
                 print("[AccelRenderer] 正在拼接完整视频...")
-                output_file = combine_full_video_direct(video_output_path)
-                # 重命名为用户文件名
+                output_file = combine_full_video_direct(
+                    video_output_path,
+                    auto_add_transition=video_trans_enable,
+                    trans_time=video_trans_time
+                )
+                # 重命名为用户文件名（先做音频均衡化）
                 final_path = os.path.join(video_output_path, f"{username}_FULL_VIDEO.mp4")
-                if os.path.exists(final_path):
-                    os.remove(final_path)
-                os.rename(output_file, final_path)
+                _normalize_video_audio(output_file, final_path)
                 print(f"[AccelRenderer] ✓ 完整视频生成完成: {final_path}")
                 return {"status": "success", "info": f"GPU加速合成完整视频成功"}
             else:
@@ -1029,39 +1033,40 @@ def render_complete_full_video(
         return {"status": "error", "info": f"合成完整视频时发生异常: {traceback.print_exc()}"}
 
 
-def combine_full_video_direct(video_clip_path):
+def combine_full_video_direct(video_clip_path, auto_add_transition=False, trans_time=1):
     """ 
         拼接指定文件夹下的所有视频片段，生成最终视频文件
-        片段需要具有正确的命名格式(0_xxx, 1_xxx, ...)以确保正确排序 
+        片段需要具有正确的命名格式(0_xxx, 1_xxx, ...)以确保正确排序
+        当 auto_add_transition=True 时使用 FFmpeg xfade 添加转场效果
     """
     print("[Info] --------------------开始拼接视频-------------------")
-    video_files = [f for f in os.listdir(video_clip_path) if f.endswith(".mp4")]
+    # 仅匹配编号前缀的片段文件，排除 final_output.mp4 / *_FULL_VIDEO.mp4 等
+    import re
+    video_files = [f for f in os.listdir(video_clip_path)
+                   if f.endswith(".mp4") and re.match(r'^\d+_', f)]
     sorted_files = sort_video_files(video_files)
     
     if not sorted_files:
         raise ValueError("Error: 没有有效的视频片段文件！")
 
-    # 创建临时目录存放 ts 文件
+    output_path = os.path.join(video_clip_path, "final_output.mp4")
+
+    # 带转场的拼接：使用 FFmpeg xfade 滤镜
+    if auto_add_transition and len(sorted_files) > 1 and trans_time > 0:
+        output_path = _combine_with_xfade(video_clip_path, sorted_files, output_path, trans_time)
+        return output_path
+
+    # 无转场的快速拼接：TS remux + concat
     temp_dir = os.path.join(video_clip_path, "temp_ts")
     os.makedirs(temp_dir, exist_ok=True)
     
     try:
-        # 1. 创建MP4文件列表
-        mp4_list_file = os.path.join(video_clip_path, "mp4_files.txt")
-        with open(mp4_list_file, 'w', encoding='utf-8') as f:
-            for file in sorted_files:
-                # 使用正斜杠替换反斜杠，并使用相对路径
-                full_path = os.path.join(video_clip_path, file).replace('\\', '/')
-                f.write(f"file '{full_path}'\n")
-
-        # 2. 创建TS文件列表并转换视频
         ts_list_file = os.path.join(video_clip_path, "ts_files.txt")
         with open(ts_list_file, 'w', encoding='utf-8') as f:
             for i, file in enumerate(sorted_files):
                 ts_name = f"{i:04d}.ts"
                 ts_path = os.path.join(temp_dir, ts_name)
                 
-                # 转换MP4为TS
                 cmd = [
                     'ffmpeg', '-y',
                     '-i', os.path.join(video_clip_path, file),
@@ -1072,14 +1077,9 @@ def combine_full_video_direct(video_clip_path):
                 ]
                 subprocess.run(cmd, check=True)
                 
-                # 写入TS文件相对路径，使用正斜杠
                 relative_ts_path = os.path.join('temp_ts', ts_name).replace('\\', '/')
                 f.write(f"file '{relative_ts_path}'\n")
 
-        # 3. 拼接TS文件并输出为MP4
-        output_path = os.path.join(video_clip_path, "final_output.mp4")
-        
-        # 使用 cwd 参数替代 os.chdir，避免进程级全局状态修改
         cmd = [
             'ffmpeg', '-y',
             '-f', 'concat',
@@ -1093,17 +1093,124 @@ def combine_full_video_direct(video_clip_path):
         print("视频拼接完成")
         
     finally:
-        # 清理临时文件
         if os.path.exists(temp_dir):
             for file in os.listdir(temp_dir):
                 os.remove(os.path.join(temp_dir, file))
             os.rmdir(temp_dir)
-        # 清理列表文件
         for txt_file in ['mp4_files.txt', 'ts_files.txt']:
             txt_path = os.path.join(video_clip_path, txt_file)
             if os.path.exists(txt_path):
                 os.remove(txt_path)
 
+    return output_path
+
+
+def _normalize_video_audio(input_path: str, output_path: str):
+    """对完整视频进行音频均衡化（单次 FFmpeg loudnorm，与 CPU 路径的 RMS 归一化效果近似）"""
+    if os.path.exists(output_path):
+        os.remove(output_path)
+    try:
+        cmd = [
+            'ffmpeg', '-y', '-hide_banner', '-loglevel', 'warning',
+            '-i', input_path,
+            '-c:v', 'copy',
+            '-af', 'loudnorm=I=-20:TP=-1.5:LRA=11',
+            '-c:a', 'aac', '-b:a', '192k',
+            output_path
+        ]
+        subprocess.run(cmd, check=True)
+        if os.path.exists(input_path) and input_path != output_path:
+            os.remove(input_path)
+        print("[AccelRenderer] ✓ 音频均衡化完成")
+    except Exception as e:
+        print(f"[AccelRenderer] Warning: 音频均衡化失败 ({e})，直接使用原始文件")
+        if not os.path.exists(output_path):
+            os.rename(input_path, output_path)
+
+
+def _get_video_duration(filepath: str) -> float:
+    """使用 ffprobe 获取视频时长"""
+    cmd = [
+        'ffprobe', '-v', 'error',
+        '-show_entries', 'format=duration',
+        '-of', 'default=noprint_wrappers=1:nokey=1',
+        filepath
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        return float(result.stdout.strip())
+    except ValueError:
+        return 0.0
+
+
+def _combine_with_xfade(video_clip_path: str, sorted_files: list,
+                         output_path: str, trans_time: float):
+    """使用 FFmpeg xfade 滤镜拼接视频片段（带淡入淡出转场）"""
+    print(f"[Info] 使用 xfade 转场拼接 ({trans_time}s)")
+    file_paths = [os.path.join(video_clip_path, f) for f in sorted_files]
+
+    # 获取每个片段的时长
+    durations = []
+    for fp in file_paths:
+        d = _get_video_duration(fp)
+        if d <= 0:
+            raise ValueError(f"无法获取视频时长: {fp}")
+        durations.append(d)
+
+    n = len(file_paths)
+
+    # 构建 FFmpeg 输入参数
+    cmd = ['ffmpeg', '-y', '-hide_banner', '-loglevel', 'warning']
+    for fp in file_paths:
+        cmd += ['-i', fp]
+
+    # 构建 xfade + acrossfade 滤镜链
+    filter_parts = []
+
+    # 先统一格式：fps/format/settb 用于视频，aformat 用于音频
+    for i in range(n):
+        filter_parts.append(f"[{i}:v]fps=30,format=yuv420p,settb=AVTB[v{i}]")
+        filter_parts.append(f"[{i}:a]aresample=44100,aformat=sample_fmts=fltp:channel_layouts=stereo[a{i}]")
+
+    # 逐对构建 xfade 和 acrossfade
+    # 累计输出时长用于计算下一个 offset
+    accumulated_duration = durations[0]
+    for i in range(n - 1):
+        offset = accumulated_duration - trans_time
+        if offset < 0:
+            offset = 0.01
+
+        if i == 0:
+            v_in_a, a_in_a = f"[v0]", f"[a0]"
+        else:
+            v_in_a, a_in_a = f"[vfade{i-1}]", f"[afade{i-1}]"
+
+        v_in_b, a_in_b = f"[v{i+1}]", f"[a{i+1}]"
+
+        if i < n - 2:
+            v_out, a_out = f"[vfade{i}]", f"[afade{i}]"
+        else:
+            v_out, a_out = "[vout]", "[aout]"
+
+        filter_parts.append(
+            f"{v_in_a}{v_in_b}xfade=transition=fade:duration={trans_time}:offset={offset:.3f}{v_out}"
+        )
+        filter_parts.append(
+            f"{a_in_a}{a_in_b}acrossfade=d={trans_time}:c1=tri:c2=tri{a_out}"
+        )
+
+        # 每次 xfade 后输出时长 = offset + duration[i+1]
+        accumulated_duration = offset + durations[i + 1]
+
+    filter_complex = ";".join(filter_parts)
+    cmd += ['-filter_complex', filter_complex]
+    cmd += ['-map', '[vout]', '-map', '[aout]']
+    cmd += ['-c:v', 'libx264', '-preset', 'fast', '-crf', '18']
+    cmd += ['-c:a', 'aac', '-b:a', '192k']
+    cmd += [output_path]
+
+    subprocess.run(cmd, check=True)
+    print("视频拼接完成（含转场效果）")
     return output_path
 
 

--- a/utils/VideoUtils.py
+++ b/utils/VideoUtils.py
@@ -812,8 +812,45 @@ def get_combined_ending_clip(ending_clips, combined_start_time, trans_time):
 def render_all_video_clips(game_type: str, style_config: dict, main_configs: list,
                            video_output_path: str, video_res: tuple, video_bitrate: str,
                            intro_configs: list = None, ending_configs: list = None,
-                           auto_add_transition=True, trans_time=1, force_render=False):
-    """ 渲染所有视频片段，并按照clip_title_name输出到指定路径文件 """
+                           auto_add_transition=True, trans_time=1, force_render=False,
+                           use_gpu_accel: bool = None):
+    """ 渲染所有视频片段，并按照clip_title_name输出到指定路径文件。
+        当 use_gpu_accel=True 时使用 Taichi GPU + FFmpeg 硬件编码加速。
+        当 use_gpu_accel=None 时从 global_config 读取配置。
+    """
+    # 检查是否启用 GPU 加速
+    if use_gpu_accel is None:
+        from utils.PageUtils import read_global_config
+        use_gpu_accel = read_global_config().get('USE_GPU_ACCEL', False)
+
+    if use_gpu_accel:
+        try:
+            from utils.TaichiAccel import init_taichi, is_available
+            init_taichi()
+            if is_available():
+                from utils.AccelRenderer import render_all_clips_accel
+                print("=" * 60)
+                print("🚀 使用 GPU 加速渲染模式 (Taichi + FFmpeg 硬件编码)")
+                print("=" * 60)
+                render_all_clips_accel(
+                    game_type=game_type,
+                    style_config=style_config,
+                    main_configs=main_configs,
+                    video_output_path=video_output_path,
+                    video_res=video_res,
+                    video_bitrate=video_bitrate,
+                    intro_configs=intro_configs,
+                    ending_configs=ending_configs,
+                    auto_add_transition=auto_add_transition,
+                    trans_time=trans_time,
+                    force_render=force_render
+                )
+                return
+            else:
+                print("[VideoUtils] Taichi 初始化失败，回退到 CPU 渲染")
+        except ImportError:
+            print("[VideoUtils] Taichi 未安装，回退到 CPU 渲染")
+
     vfile_prefix = 0
 
     def modify_and_rend_clip(clip, config, prefix, auto_add_transition, trans_time, override_clip_name=None):
@@ -897,9 +934,53 @@ def render_complete_full_video(
         video_output_path: str, 
         intro_configs: list=None, ending_configs: list=None,
         video_res: tuple = (1920, 1080), video_bitrate: str = "4000k",
-        video_trans_enable: bool = True, video_trans_time: float = 1.0, full_last_clip: bool = False):
-    """ 根据完整配置合成完整视频，并保存到指定路径的文件 """
+        video_trans_enable: bool = True, video_trans_time: float = 1.0, full_last_clip: bool = False,
+        use_gpu_accel: bool = None):
+    """ 根据完整配置合成完整视频，并保存到指定路径的文件。
+        当 use_gpu_accel=True 时，先用 GPU 加速渲染所有片段，再用 FFmpeg 拼接。
+    """
+    # 检查是否启用 GPU 加速
+    if use_gpu_accel is None:
+        from utils.PageUtils import read_global_config
+        use_gpu_accel = read_global_config().get('USE_GPU_ACCEL', False)
 
+    if use_gpu_accel:
+        try:
+            from utils.TaichiAccel import init_taichi, is_available
+            init_taichi()
+            if is_available():
+                from utils.AccelRenderer import render_all_clips_accel, detect_hw_encoder
+                print("=" * 60)
+                print("🚀 使用 GPU 加速完整视频生成模式")
+                print("=" * 60)
+                # 第一步：GPU 加速渲染所有片段
+                render_all_clips_accel(
+                    game_type=game_type,
+                    style_config=style_config,
+                    main_configs=main_configs,
+                    video_output_path=video_output_path,
+                    video_res=video_res,
+                    video_bitrate=video_bitrate,
+                    intro_configs=intro_configs,
+                    ending_configs=ending_configs,
+                    force_render=True
+                )
+                # 第二步：使用 FFmpeg 直接拼接（速度快，无需再次编码）
+                print("[AccelRenderer] 正在拼接完整视频...")
+                output_file = combine_full_video_direct(video_output_path)
+                # 重命名为用户文件名
+                final_path = os.path.join(video_output_path, f"{username}_FULL_VIDEO.mp4")
+                if os.path.exists(final_path):
+                    os.remove(final_path)
+                os.rename(output_file, final_path)
+                print(f"[AccelRenderer] ✓ 完整视频生成完成: {final_path}")
+                return {"status": "success", "info": f"GPU加速合成完整视频成功"}
+            else:
+                print("[VideoUtils] Taichi 初始化失败，回退到 CPU 渲染")
+        except ImportError:
+            print("[VideoUtils] Taichi 未安装，回退到 CPU 渲染")
+
+    # CPU 渲染回退路径
     print(f"正在合成完整视频...")
     try:
         final_video = create_full_video(

--- a/utils/VideoUtils.py
+++ b/utils/VideoUtils.py
@@ -963,7 +963,9 @@ def render_complete_full_video(
                     video_bitrate=video_bitrate,
                     intro_configs=intro_configs,
                     ending_configs=ending_configs,
-                    force_render=True
+                    auto_add_transition=video_trans_enable,
+                    trans_time=video_trans_time,
+                    force_render=force_render
                 )
                 # 第二步：使用 FFmpeg 直接拼接（速度快，无需再次编码）
                 print("[AccelRenderer] 正在拼接完整视频...")
@@ -1077,21 +1079,17 @@ def combine_full_video_direct(video_clip_path):
         # 3. 拼接TS文件并输出为MP4
         output_path = os.path.join(video_clip_path, "final_output.mp4")
         
-        # 切换到视频目录执行拼接命令
-        current_dir = os.getcwd()
-        os.chdir(video_clip_path)
-        
+        # 使用 cwd 参数替代 os.chdir，避免进程级全局状态修改
         cmd = [
             'ffmpeg', '-y',
             '-f', 'concat',
             '-safe', '0',
-            '-i', 'ts_files.txt',  # 使用相对路径
+            '-i', 'ts_files.txt',
             '-c', 'copy',
-            'final_output.mp4'  # 使用相对路径
+            'final_output.mp4'
         ]
         
-        subprocess.run(cmd, check=True)
-        os.chdir(current_dir)  # 恢复原始工作目录
+        subprocess.run(cmd, check=True, cwd=video_clip_path)
         print("视频拼接完成")
         
     finally:
@@ -1100,6 +1098,11 @@ def combine_full_video_direct(video_clip_path):
             for file in os.listdir(temp_dir):
                 os.remove(os.path.join(temp_dir, file))
             os.rmdir(temp_dir)
+        # 清理列表文件
+        for txt_file in ['mp4_files.txt', 'ts_files.txt']:
+            txt_path = os.path.join(video_clip_path, txt_file)
+            if os.path.exists(txt_path):
+                os.remove(txt_path)
 
     return output_path
 


### PR DESCRIPTION
## 概述

使用 Taichi GPU 计算 + FFmpeg 硬件编码，替代 MoviePy 逐帧 CPU 渲染，作为**可选加速后端**（默认关闭，自动回退 CPU）。

## 基准测试（1920×1080, 300帧）

| 场景 | CPU (NumPy + libx264) | GPU (Taichi + VideoToolbox) | 加速比 |
|------|----------------------|---------------------------|--------|
| 合成 | 47 fps (21.1 ms/帧) | 127 fps (7.9 ms/帧) | **2.67x** |
| 端到端含编码 | 42 fps (23.7 ms/帧) | 102 fps (9.8 ms/帧) | **2.42x** |

> 测试环境: macOS arm64, Metal GPU 后端, h264_videotoolbox 硬件编码器

## 核心改动

### 新增文件
- **`utils/TaichiAccel.py`** — GPU 加速内核模块
  - 逐像素并行合成：`for i, j in ti.ndrange(H, W)` 映射为 GPU thread
  - 蒙版独立 2D 数组传入，kernel 内无动态 shape 分支
  - `FrameCompositor` 类：预计算静态层 + 缓冲区复用 + 零拷贝快速路径
  - 自动选择最佳后端：macOS Metal > Vulkan > CPU；Linux/Win CUDA > Vulkan > OpenGL > CPU

- **`utils/AccelRenderer.py`** — 加速渲染管线
  - 硬件编码器自动检测（NVENC / VideoToolbox / AMF / QSV → libx264 回退）
  - cv2 解码 → Taichi GPU 合成 → FFmpeg stdin pipe 编码

### 修改文件
- **`utils/VideoUtils.py`** — `render_all_video_clips()` / `render_complete_full_video()` 新增 `use_gpu_accel` 参数，Taichi 不可用时自动回退原始 MoviePy 路径
- **`st_pages/Composite_Videos.py`** — UI 新增「启用 Taichi GPU 加速」复选框
- **`global_config.yaml`** — 新增 `USE_GPU_ACCEL: false`
- **`requirements.txt`** — 新增 `taichi>=1.7.0`

## 使用方式

1. 安装依赖：`pip install taichi>=1.7.0`
2. 在「合成视频」页面勾选「启用 Taichi GPU 加速」
3. 或在 `global_config.yaml` 中设置 `USE_GPU_ACCEL: true`

未安装 Taichi 时自动回退 CPU 路径，对现有功能无影响。
