### PR TITLE
fix: NVENC检测/中文路径/60fps三项修复

### DIFF
--- a/st_pages/Composite_Videos.py
+++ b/st_pages/Composite_Videos.py
@@ -80,7 +80,8 @@ st.markdown("#### 视频生成设置")
 
 _mode_index = 0 if G_config['ONLY_GENERATE_CLIPS'] else 1
 _video_res = G_config['VIDEO_RES']
-_video_bitrate = 5000 # TODO：存储到配置文件中
+_video_bitrate = G_config.get('VIDEO_BITRATE', 5000)
+_video_fps = G_config.get('VIDEO_FPS', 60)
 _trans_enable = G_config['VIDEO_TRANS_ENABLE']
 _trans_time = G_config['VIDEO_TRANS_TIME']
 
@@ -110,6 +111,10 @@ with vcof_col2:
     with st.container(border=True):
         st.write("视频比特率(kbps)")  
         v_bitrate = st.number_input("视频比特率", min_value=1000, max_value=10000, value=_video_bitrate)
+
+with st.container(border=True):
+    st.write("视频帧率")
+    v_fps = st.number_input("输出帧率 (fps)", min_value=24, max_value=120, value=_video_fps, step=1)
 
 _gpu_accel = G_config.get('USE_GPU_ACCEL', False)
 with st.container(border=True):
@@ -154,6 +159,7 @@ def save_video_render_config():
     G_config['ONLY_GENERATE_CLIPS'] = v_mode_index == 0
     G_config['VIDEO_RES'] = (v_res_width, v_res_height)
     G_config['VIDEO_BITRATE'] = v_bitrate
+    G_config['VIDEO_FPS'] = v_fps
     G_config['VIDEO_TRANS_ENABLE'] = trans_enable
     G_config['VIDEO_TRANS_TIME'] = trans_time
     G_config['USE_GPU_ACCEL'] = gpu_accel
@@ -199,6 +205,7 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
                         video_output_path=video_output_path,
                         video_res=video_res,
                         video_bitrate=v_bitrate_kbps,
+                        video_fps=v_fps,
                         intro_configs=intro_configs,
                         ending_configs=ending_configs,
                         trans_time=trans_time,
@@ -228,6 +235,7 @@ if st.button("开始生成视频", use_container_width=True, type="primary"):
                         video_output_path=video_output_path,
                         video_res=video_res,
                         video_bitrate=v_bitrate_kbps,
+                        video_fps=v_fps,
                         video_trans_enable=trans_enable,
                         video_trans_time=trans_time,
                         full_last_clip=False,
@@ -277,6 +285,7 @@ with st.expander("展开其他视频生成方案"):
                             video_output_path=video_output_path,
                             video_res=video_res,
                             video_bitrate=v_bitrate_kbps,
+                            video_fps=v_fps,
                             video_trans_enable=trans_enable,
                             video_trans_time=trans_time,
                             full_last_clip=False,
@@ -298,6 +307,7 @@ with st.expander("展开其他视频生成方案"):
                         video_output_path=video_output_path, 
                         video_res=video_res, 
                         video_bitrate=v_bitrate_kbps,
+                        video_fps=v_fps,
                         intro_configs=intro_configs,
                         ending_configs=ending_configs,
                         auto_add_transition=trans_enable, 
@@ -306,7 +316,7 @@ with st.expander("展开其他视频生成方案"):
                     )
                     st.info("已启动批量视频片段生成，请在控制台窗口查看进度……")
                 with st.spinner("正在拼接视频……"):
-                    combine_full_video_direct(video_output_path)
+                    combine_full_video_direct(video_output_path, video_fps=v_fps)
                 st.success("所有任务已退出，请从上方按钮打开文件夹查看视频生成结果")
 
     with st.container(border=True):
@@ -337,6 +347,7 @@ with st.expander("展开其他视频生成方案"):
                         video_output_path=video_output_path, 
                         video_res=video_res, 
                         video_bitrate=v_bitrate_kbps,
+                        video_fps=v_fps,
                         intro_configs=intro_configs,
                         ending_configs=ending_configs,
                         auto_add_transition=trans_enable,

--- a/st_pages/Edit_Video_Content.py
+++ b/st_pages/Edit_Video_Content.py
@@ -404,7 +404,8 @@ if video_configs:
                         video_file_name=target_video_filename,
                         video_output_path=video_output_path,
                         video_res=v_res,
-                        video_bitrate=v_bitrate_kbps
+                        video_bitrate=v_bitrate_kbps,
+                        video_fps=G_config.get('VIDEO_FPS', 60)
                     )
                 if res['status'] == 'success':
                     st.success(res['info'])

--- a/utils/AccelRenderer.py
+++ b/utils/AccelRenderer.py
@@ -116,7 +116,7 @@ def detect_hw_encoder() -> Tuple[str, str]:
                 # 实际探测编码器是否能工作（驱动版本可能不满足要求）
                 probe = subprocess.run(
                     [get_ffmpeg_binary('ffmpeg'), '-y', '-hide_banner', '-loglevel', 'error',
-                     '-f', 'lavfi', '-i', 'nullsrc=s=64x64:d=0.04:r=25',
+                     '-f', 'lavfi', '-i', 'nullsrc=s=256x256:d=0.1:r=30',
                      '-c:v', codec, '-f', 'null', '-'],
                     capture_output=True, text=True, timeout=10
                 )
@@ -349,7 +349,12 @@ def _prepare_bg_frame(bg_path: str, resolution: tuple, is_video: bool = False,
             return cv2.resize(frame, resolution)
     
     # 静态图片背景
-    img = cv2.imread(bg_path, cv2.IMREAD_COLOR)
+    try:
+        with open(bg_path, 'rb') as f:
+            img_array = np.frombuffer(f.read(), dtype=np.uint8)
+            img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+    except Exception:
+        img = None
     if img is None:
         return np.zeros((resolution[1], resolution[0], 3), dtype=np.uint8)
     img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
@@ -381,7 +386,12 @@ def _load_image_rgba(path: str) -> np.ndarray:
 
 def _load_image_rgb(path: str, target_size: tuple = None) -> np.ndarray:
     """加载图片为 RGB numpy 数组"""
-    img = cv2.imread(path, cv2.IMREAD_COLOR)
+    try:
+        with open(path, 'rb') as f:
+            img_array = np.frombuffer(f.read(), dtype=np.uint8)
+            img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+    except Exception:
+        img = None
     if img is None:
         if target_size:
             return np.zeros((target_size[1], target_size[0], 3), dtype=np.uint8)

--- a/utils/VideoUtils.py
+++ b/utils/VideoUtils.py
@@ -813,6 +813,7 @@ def get_combined_ending_clip(ending_clips, combined_start_time, trans_time):
 
 def render_all_video_clips(game_type: str, style_config: dict, main_configs: list,
                            video_output_path: str, video_res: tuple, video_bitrate: str,
+                           video_fps: int = 60,
                            intro_configs: list = None, ending_configs: list = None,
                            auto_add_transition=True, trans_time=1, force_render=False,
                            use_gpu_accel: bool = None, progress_callback=None):
@@ -846,6 +847,7 @@ def render_all_video_clips(game_type: str, style_config: dict, main_configs: lis
                     auto_add_transition=auto_add_transition,
                     trans_time=trans_time,
                     force_render=force_render,
+                    fps=video_fps,
                     progress_callback=progress_callback
                 )
                 return
@@ -882,7 +884,7 @@ def render_all_video_clips(game_type: str, style_config: dict, main_configs: lis
             ])
         # 直接渲染clip为视频文件
         print(f"正在合成视频片段: {prefix}_{clip_title_name}.mp4")
-        clip.write_videofile(output_file, fps=30, threads=4, preset='ultrafast', bitrate=video_bitrate)
+        clip.write_videofile(output_file, fps=video_fps, threads=4, preset='ultrafast', bitrate=video_bitrate)
         clip.close()
         # 强制垃圾回收
         del clip
@@ -912,7 +914,8 @@ def render_one_video_clip(
         config: dict, 
         style_config: dict, 
         video_output_path: str, video_res: tuple, video_bitrate: str,
-        video_file_name: str=None
+        video_file_name: str=None,
+        video_fps: int = 60
     ):
     """ 根据一条配置合成单个视频片段，并保存到指定路径的文件 """
     if not video_file_name:
@@ -921,7 +924,7 @@ def render_one_video_clip(
     try:
         clip = create_video_segment(game_type, config, style_config, video_res)
         clip.write_videofile(os.path.join(video_output_path, video_file_name), 
-                             fps=30, threads=4, preset='ultrafast', bitrate=video_bitrate)
+                             fps=video_fps, threads=4, preset='ultrafast', bitrate=video_bitrate)
         clip.close()
         return {"status": "success", "info": f"合成视频片段{video_file_name}成功"}
     except Exception as e:
@@ -937,6 +940,7 @@ def render_complete_full_video(
         video_output_path: str, 
         intro_configs: list=None, ending_configs: list=None,
         video_res: tuple = (1920, 1080), video_bitrate: str = "4000k",
+        video_fps: int = 60,
         video_trans_enable: bool = True, video_trans_time: float = 1.0, full_last_clip: bool = False,
         use_gpu_accel: bool = None, use_baked_fade: bool = None, progress_callback=None):
     """ 根据完整配置合成完整视频，并保存到指定路径的文件。
@@ -1079,7 +1083,7 @@ def render_complete_full_video(
         
         final_video.write_videofile(
             output_file, 
-            fps=30,
+            fps=video_fps,
             threads=12,  # CPU模式使用多线程
             codec='libx264',
             preset='medium',  # balanced 质量：medium preset
@@ -1121,7 +1125,7 @@ def combine_full_video_direct(video_clip_path, auto_add_transition=False, trans_
     # 带转场的拼接：使用 FFmpeg xfade 滤镜
     if auto_add_transition and len(sorted_files) > 1 and trans_time > 0:
         output_path = _combine_with_xfade(video_clip_path, sorted_files, output_path, trans_time,
-                                          codec=codec, bitrate=bitrate)
+                                          codec=codec, bitrate=bitrate, video_fps=video_fps)
         print(f"[Timer] 拼接(xfade)总耗时: {time.perf_counter() - t_concat_start:.2f}s")
         return output_path
 
@@ -1221,7 +1225,8 @@ def _get_video_duration(filepath: str) -> float:
 
 def _combine_with_xfade(video_clip_path: str, sorted_files: list,
                          output_path: str, trans_time: float,
-                         codec: str = None, bitrate: str = "5000k"):
+                         codec: str = None, bitrate: str = "5000k",
+                         video_fps: int = 60):
     """使用 FFmpeg xfade 滤镜拼接视频片段（带淡入淡出转场）
     
     Args:
@@ -1254,7 +1259,7 @@ def _combine_with_xfade(video_clip_path: str, sorted_files: list,
     for i, duration in enumerate(durations):
         filter_parts.append(
             f"[{i}:v]setpts=PTS-STARTPTS,trim=duration={duration:.6f},"
-            f"setpts=PTS-STARTPTS,fps=30,format=yuv420p,settb=AVTB[v{i}]"
+            f"setpts=PTS-STARTPTS,fps={video_fps},format=yuv420p,settb=AVTB[v{i}]"
         )
         filter_parts.append(
             f"[{i}:a]asetpts=PTS-STARTPTS,aresample=48000:async=1:first_pts=0,"

--- a/utils/VideoUtils.py
+++ b/utils/VideoUtils.py
@@ -990,6 +990,7 @@ def render_complete_full_video(
                         auto_add_transition=False,
                         trans_time=video_trans_time,
                         force_render=True,
+                        fps=video_fps,
                         progress_callback=progress_callback
                     )
                     print(f"[Timer] 步骤1 - 渲染所有片段耗时: {time.perf_counter() - t_step:.2f}s")
@@ -1002,7 +1003,8 @@ def render_complete_full_video(
                         auto_add_transition=True,
                         trans_time=video_trans_time,
                         codec=hw_codec,
-                        bitrate=video_bitrate
+                        bitrate=video_bitrate,
+                        video_fps=video_fps
                     )
                     print(f"[Timer] 步骤2 - 视频拼接(xfade)耗时: {time.perf_counter() - t_step:.2f}s")
                 else:
@@ -1026,6 +1028,7 @@ def render_complete_full_video(
                         auto_add_transition=video_trans_enable,
                         trans_time=video_trans_time,
                         force_render=True,
+                        fps=video_fps,
                         progress_callback=progress_callback
                     )
                     print(f"[Timer] 步骤1 - 渲染所有片段耗时: {time.perf_counter() - t_step:.2f}s")
@@ -1036,7 +1039,8 @@ def render_complete_full_video(
                     output_file = combine_full_video_direct(
                         video_output_path,
                         auto_add_transition=False,
-                        trans_time=video_trans_time
+                        trans_time=video_trans_time,
+                        video_fps=video_fps
                     )
                     print(f"[Timer] 步骤2 - 视频拼接(流拷贝)耗时: {time.perf_counter() - t_step:.2f}s")
 
@@ -1101,7 +1105,7 @@ def render_complete_full_video(
 
 
 def combine_full_video_direct(video_clip_path, auto_add_transition=False, trans_time=1,
-                              codec=None, bitrate="5000k"):
+                              codec=None, bitrate="5000k", video_fps=60):
     """ 
         拼接指定文件夹下的所有视频片段，生成最终视频文件
         片段需要具有正确的命名格式(0_xxx, 1_xxx, ...)以确保正确排序


### PR DESCRIPTION
## 修复 mai-gen-videob50 的三个问题

### 1. NVENC 检测分辨率问题
**问题**：`detect_hw_encoder()` 使用 64×64 分辨率探测编码器，但 RTX 3060 的最低要求是 256×256，导致在部分驱动版本下误判为不可用。

**修复**：将探测分辨率从 `64x64` 改为 `256x256`，同时将时长从 0.04s 改为 0.1s、帧率从 25 改为 30。

### 2. 中文路径支持
**问题**：Windows 路径中包含中文时，`cv2.imread()` 无法正确读取文件。

**修复**：将 `_prepare_bg_frame()` 和 `_load_image_rgb()` 中的 `cv2.imread(path)` 替换为二进制读取 + `cv2.imdecode()`。

### 3. 60fps 输出选项
**问题**：输出帧率硬编码为 30fps，无法满足高帧率需求。

**修复**：
- UI 添加帧率滑块（24-120，默认 60），配置持久化到 `VIDEO_FPS`
- `video_fps` 参数贯穿所有渲染函数：`render_all_video_clips`、`render_one_video_clip`、`render_complete_full_video`、`_combine_with_xfade`
- CPU 路径 `write_videofile` 和 FFmpeg xfade 滤镜链均已透传 `video_fps`

---

## Review 反馈修复（2026-05-04）

修复 60fps 不是端到端生效的问题：
1. `render_complete_full_video` CPU 路径：`fps=30` → `fps=video_fps`
2. `_combine_with_xfade` 滤镜链：`fps=30` → `fps={video_fps}`，新增 `video_fps` 参数
3. `render_one_video_clip`：新增 `video_fps` 参数并透传

---

修复文件：`utils/AccelRenderer.py`、`utils/VideoUtils.py`、`st_pages/Edit_Video_Content.py`
